### PR TITLE
remove instance overhead

### DIFF
--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -165,7 +165,13 @@ impl Des {
 
 				match **ty {
 					Ty::Instance(class) => {
-						self.push_assign(into.clone(), Var::from("incoming_inst").eindex(self.readu16()).into());
+						self.push_assign(Var::from("incoming_ipos"), Expr::from("incoming_ipos").add(1.0.into()));
+						self.push_assign(
+							into.clone(),
+							Var::from("incoming_inst")
+								.eindex(Var::from("incoming_ipos").into())
+								.into(),
+						);
 
 						if self.checks && class.is_some() {
 							self.push_assert(
@@ -209,7 +215,13 @@ impl Des {
 			}
 
 			Ty::Instance(class) => {
-				self.push_assign(into.clone(), Var::from("incoming_inst").eindex(self.readu16()).into());
+				self.push_assign(Var::from("incoming_ipos"), Expr::from("incoming_ipos").add(1.0.into()));
+				self.push_assign(
+					into.clone(),
+					Var::from("incoming_inst")
+						.eindex(Var::from("incoming_ipos").into())
+						.into(),
+				);
 
 				// always assert non-optional instances as roblox
 				// will sometimes vaporize them

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -211,7 +211,11 @@ impl Ser {
 					);
 				}
 
-				self.push_writeu16(Var::from("alloc_inst").call(vec![from_expr]))
+				self.push_stmt(Stmt::Call(
+					Var::from("table").nindex("insert"),
+					None,
+					vec!["outgoing_inst".into(), from_expr],
+				))
 			}
 
 			Ty::Vector3 => {

--- a/zap/src/output/luau/base.luau
+++ b/zap/src/output/luau/base.luau
@@ -7,6 +7,7 @@ local outgoing_apos: number
 local incoming_buff: buffer
 local incoming_read: number
 local incoming_inst: { Instance }
+local incoming_ipos: number
 
 local function alloc(len: number)
 	if outgoing_used + len > outgoing_size then
@@ -24,12 +25,6 @@ local function alloc(len: number)
 	outgoing_used = outgoing_used + len
 
 	return outgoing_apos
-end
-
-local function alloc_inst(inst: Instance)
-	table.insert(outgoing_inst, inst)
-
-	return #outgoing_inst
 end
 
 local function read(len: number)

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -76,6 +76,7 @@ impl<'src> ClientOutput<'src> {
 		self.push_line("incoming_buff = buff");
 		self.push_line("incoming_inst = inst");
 		self.push_line("incoming_read = 0");
+		self.push_line("incoming_ipos = 0");
 
 		self.push_line("local len = buffer.len(buff)");
 		self.push_line("while incoming_read < len do");
@@ -168,6 +169,7 @@ impl<'src> ClientOutput<'src> {
 		self.push_line("incoming_buff = buff");
 		self.push_line("incoming_inst = inst");
 		self.push_line("incoming_read = 0");
+		self.push_line("incoming_ipos = 0");
 
 		self.push_line(&format!(
 			"local id = buffer.read{}(buff, read({}))",

--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -76,6 +76,7 @@ impl<'a> ServerOutput<'a> {
 		self.push_line("incoming_buff = buff");
 		self.push_line("incoming_inst = inst");
 		self.push_line("incoming_read = 0");
+		self.push_line("incoming_ipos = 0");
 
 		self.push_line("local len = buffer.len(buff)");
 		self.push_line("while incoming_read < len do");
@@ -169,6 +170,7 @@ impl<'a> ServerOutput<'a> {
 		self.push_line("incoming_buff = buff");
 		self.push_line("incoming_inst = inst");
 		self.push_line("incoming_read = 0");
+		self.push_line("incoming_ipos = 0");
 
 		self.push_line(&format!(
 			"local id = buffer.read{}(buff, read({}))",
@@ -328,8 +330,9 @@ impl<'a> ServerOutput<'a> {
 				self.push_line("for player, outgoing in player_map do");
 				self.indent();
 				self.push_line("load(outgoing)");
-				self.push_line("local pos = alloc(used)");
-				self.push_line("buffer.copy(outgoing_buff, pos, buff, 0, used)");
+				self.push_line("alloc(used)");
+				self.push_line("buffer.copy(outgoing_buff, outgoing_apos, buff, 0, used)");
+				self.push_line("table.move(inst, 1, #inst, #outgoing_inst + 1, outgoing_inst)");
 				self.push_line("player_map[player] = save()");
 				self.dedent();
 				self.push_line("end");
@@ -373,8 +376,9 @@ impl<'a> ServerOutput<'a> {
 				self.push_line(&format!("if player ~= {except} then"));
 				self.indent();
 				self.push_line("load(outgoing)");
-				self.push_line("local pos = alloc(used)");
-				self.push_line("buffer.copy(outgoing_buff, pos, buff, 0, used)");
+				self.push_line("alloc(used)");
+				self.push_line("buffer.copy(outgoing_buff, outgoing_apos, buff, 0, used)");
+				self.push_line("table.move(inst, 1, #inst, #outgoing_inst + 1, outgoing_inst)");
 				self.push_line("player_map[player] = save()");
 				self.dedent();
 				self.push_line("end");
@@ -426,8 +430,9 @@ impl<'a> ServerOutput<'a> {
 				self.push_line(&format!("for _, player in {list} do"));
 				self.indent();
 				self.push_line("load(player_map[player])");
-				self.push_line("local pos = alloc(used)");
-				self.push_line("buffer.copy(outgoing_buff, pos, buff, 0, used)");
+				self.push_line("alloc(used)");
+				self.push_line("buffer.copy(outgoing_buff, outgoing_apos, buff, 0, used)");
+				self.push_line("table.move(inst, 1, #inst, #outgoing_inst + 1, outgoing_inst)");
 				self.push_line("player_map[player] = save()");
 				self.dedent();
 				self.push_line("end");


### PR DESCRIPTION
This also fixes instances not being sent when `FireAll`, `FireExcept` and `FireList` are used.

Closes #32