### PR TITLE
Add the `unknown` type

### DIFF
--- a/docs/.vitepress/components/Editor.vue
+++ b/docs/.vitepress/components/Editor.vue
@@ -132,6 +132,7 @@ const beforeMount = (monaco: Monaco) => {
 		"boolean",
 		"string",
 		"buffer",
+		"unknown",
 		"Instance",
 		"Vector3",
 	] as const;

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -88,6 +88,7 @@ pub enum Ty<'src> {
 
 	Vector3,
 	Boolean,
+	Unknown,
 }
 
 impl<'src> Ty<'src> {
@@ -106,6 +107,7 @@ impl<'src> Ty<'src> {
 			Self::Enum(enum_ty) => enum_ty.max_size(config, recursed),
 			Self::Struct(struct_ty) => struct_ty.max_size(config, recursed),
 			Self::Instance(_) => Some(2),
+			Self::Unknown => None,
 			Self::Ref(name) => {
 				if recursed.contains(name) {
 					None

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -185,6 +185,16 @@ impl Des {
 						}
 					}
 
+					Ty::Unknown => {
+						self.push_assign(Var::from("incoming_ipos"), Expr::from("incoming_ipos").add(1.0.into()));
+						self.push_assign(
+							into.clone(),
+							Var::from("incoming_inst")
+								.eindex(Var::from("incoming_ipos").into())
+								.into(),
+						);
+					}
+
 					_ => self.push_ty(ty, into.clone()),
 				}
 
@@ -238,6 +248,9 @@ impl Des {
 					)
 				}
 			}
+
+			// unknown is always an opt
+			Ty::Unknown => unreachable!(),
 
 			Ty::Boolean => self.push_assign(into, self.readu8().eq(1.0.into())),
 			Ty::Vector3 => {

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -218,6 +218,12 @@ impl Ser {
 				))
 			}
 
+			Ty::Unknown => self.push_stmt(Stmt::Call(
+				Var::from("table").nindex("insert"),
+				None,
+				vec!["outgoing_inst".into(), from_expr],
+			)),
+
 			Ty::Vector3 => {
 				self.push_writef32(from.clone().nindex("X").into());
 				self.push_writef32(from.clone().nindex("Y").into());

--- a/zap/src/output/luau/mod.rs
+++ b/zap/src/output/luau/mod.rs
@@ -159,6 +159,7 @@ pub trait Output {
 
 			Ty::Instance(name) => self.push(name.unwrap_or("Instance")),
 
+			Ty::Unknown => self.push("unknown"),
 			Ty::Boolean => self.push("boolean"),
 			Ty::Vector3 => self.push("Vector3"),
 		}

--- a/zap/src/output/typescript/mod.rs
+++ b/zap/src/output/typescript/mod.rs
@@ -172,6 +172,7 @@ pub trait Output {
 
 			Ty::Instance(name) => self.push(name.unwrap_or("Instance")),
 
+			Ty::Unknown => self.push("unknown"),
 			Ty::Boolean => self.push("boolean"),
 			Ty::Vector3 => self.push("Vector3"),
 		}

--- a/zap/src/parser/reports.rs
+++ b/zap/src/parser/reports.rs
@@ -76,6 +76,10 @@ pub enum Report<'src> {
 		min: f64,
 		max: f64,
 	},
+
+	AnalyzeInvalidOptionalType {
+		span: Span,
+	},
 }
 
 impl<'src> Report<'src> {
@@ -98,6 +102,7 @@ impl<'src> Report<'src> {
 			Self::AnalyzeUnknownOptName { .. } => Severity::Warning,
 			Self::AnalyzeUnknownTypeRef { .. } => Severity::Error,
 			Self::AnalyzeNumOutsideRange { .. } => Severity::Error,
+			Self::AnalyzeInvalidOptionalType { .. } => Severity::Error,
 		}
 	}
 
@@ -123,6 +128,7 @@ impl<'src> Report<'src> {
 			Self::AnalyzeUnknownOptName { .. } => "unknown opt name".to_string(),
 			Self::AnalyzeUnknownTypeRef { name, .. } => format!("unknown type reference '{}'", name),
 			Self::AnalyzeNumOutsideRange { .. } => "number outside range".to_string(),
+			Self::AnalyzeInvalidOptionalType { .. } => "type must not be optional".to_string(),
 		}
 	}
 
@@ -145,6 +151,7 @@ impl<'src> Report<'src> {
 			Self::AnalyzeUnknownOptName { .. } => "3008",
 			Self::AnalyzeUnknownTypeRef { .. } => "3009",
 			Self::AnalyzeNumOutsideRange { .. } => "3010",
+			Self::AnalyzeInvalidOptionalType { .. } => "3011",
 		}
 	}
 
@@ -216,6 +223,10 @@ impl<'src> Report<'src> {
 			Self::AnalyzeNumOutsideRange { span, .. } => {
 				vec![Label::primary((), span.clone()).with_message("number outside range")]
 			}
+
+			Self::AnalyzeInvalidOptionalType { span, .. } => {
+				vec![Label::primary((), span.clone()).with_message("must be removed")]
+			}
 		}
 	}
 
@@ -260,6 +271,9 @@ impl<'src> Report<'src> {
 			Self::AnalyzeNumOutsideRange { min, max, .. } => Some(vec![
 				format!("(inclusive) min: {}", min),
 				format!("(inclusive) max: {}", max),
+			]),
+			Self::AnalyzeInvalidOptionalType { .. } => Some(vec![
+				"this type can only be used when it is not marked as optional".to_string(),
 			]),
 		}
 	}


### PR DESCRIPTION
Docs are left to write.

The `unknown` type is an escape from when we do not know the structure of the data and must instead get Roblox to serialise it. This can be a footgun and only should be used in specific circumstances. 