### PR TITLE
rewrite convert

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,15 +31,9 @@ fn main() -> Result<()> {
 	let diagnostics = ret.diagnostics;
 
 	if let Some(code) = code {
-		let server_path = config_path
-			.parent()
-			.unwrap()
-			.join(code.server.path.unwrap_or(PathBuf::from("./network/server.lua")));
+		let server_path = config_path.parent().unwrap().join(code.server.path);
 
-		let client_path = config_path
-			.parent()
-			.unwrap()
-			.join(code.client.path.unwrap_or(PathBuf::from("./network/client.lua")));
+		let client_path = config_path.parent().unwrap().join(code.client.path);
 
 		if let Some(parent) = server_path.parent() {
 			std::fs::create_dir_all(parent)?;

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -98,6 +98,11 @@ pub enum Ty<'src> {
 }
 
 impl<'src> Ty<'src> {
+	/// Returns the amount of data used by this type in bytes.
+	///
+	/// Note that this is not the same as the size of the type in the buffer.
+	/// For example, an `Instance` will always send 4 bytes of data, but the
+	/// size of the type in the buffer will be 0 bytes.
 	pub fn size(
 		&self,
 		tydecls: &HashMap<&'src str, TyDecl<'src>>,
@@ -169,14 +174,14 @@ impl<'src> Ty<'src> {
 			Self::Enum(enum_ty) => enum_ty.size(tydecls, recursed),
 			Self::Struct(struct_ty) => struct_ty.size(tydecls, recursed),
 
-			Self::Instance(_) => (0, Some(0)),
+			Self::Instance(_) => (4, Some(4)),
 
 			Self::Boolean => (1, Some(1)),
 			Self::Color3 => (12, Some(12)),
 			Self::Vector3 => (12, Some(12)),
 			Self::AlignedCFrame => (13, Some(13)),
 			Self::CFrame => (48, Some(48)),
-			Self::Unknown => (0, Some(0)),
+			Self::Unknown => (0, None),
 		}
 	}
 }

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashSet, fmt::Display};
+use std::{
+	collections::{HashMap, HashSet},
+	fmt::Display,
+};
 
 #[derive(Debug, Clone)]
 pub struct Config<'src> {
@@ -8,8 +11,8 @@ pub struct Config<'src> {
 	pub write_checks: bool,
 	pub typescript: bool,
 
-	pub server_output: Option<&'src str>,
-	pub client_output: Option<&'src str>,
+	pub server_output: &'src str,
+	pub client_output: &'src str,
 
 	pub casing: Casing,
 }
@@ -95,37 +98,85 @@ pub enum Ty<'src> {
 }
 
 impl<'src> Ty<'src> {
-	pub fn max_size(&self, config: &Config<'src>, recursed: &mut HashSet<&'src str>) -> Option<usize> {
+	pub fn size(
+		&self,
+		tydecls: &HashMap<&'src str, TyDecl<'src>>,
+		recursed: &mut HashSet<&'src str>,
+	) -> (usize, Option<usize>) {
 		match self {
-			Self::Num(numty, _) => Some(numty.size()),
-			Self::Color3 => Some(NumTy::U8.size() * 3),
-			Self::Vector3 => Some(NumTy::F32.size() * 3),
-			Self::AlignedCFrame => Some(NumTy::U8.size() + NumTy::F32.size() * 3),
-			Self::CFrame => Some(NumTy::F32.size() * 12),
-			Self::Boolean => Some(1),
-			Self::Opt(ty) => ty.max_size(config, recursed).map(|size| size + 1),
-			Self::Str(len) => len.max().map(|len| len as usize),
-			Self::Buf(len) => len.max().map(|len| len as usize),
-			Self::Arr(ty, range) => range
-				.max()
-				.and_then(|len| ty.max_size(config, recursed).map(|size| size * len as usize)),
-			Self::Map(..) => None,
-			Self::Enum(enum_ty) => enum_ty.max_size(config, recursed),
-			Self::Struct(struct_ty) => struct_ty.max_size(config, recursed),
-			Self::Instance(_) => Some(2),
-			Self::Unknown => None,
-			Self::Ref(name) => {
-				if recursed.contains(name) {
-					None
+			Self::Num(numty, ..) => (numty.size(), Some(numty.size())),
+
+			Self::Str(len) => {
+				if let Some(exact) = len.exact() {
+					(exact as usize, Some(exact as usize))
 				} else {
-					recursed.insert(name);
-					config
-						.tydecls
-						.iter()
-						.find(|tydecl| tydecl.name == *name)
-						.and_then(|tydecl| tydecl.ty.max_size(config, recursed))
+					(
+						len.min().map(|min| (min as usize) + 2).unwrap_or(2),
+						len.max().map(|max| (max as usize) + 2),
+					)
 				}
 			}
+
+			Self::Buf(len) => {
+				if let Some(exact) = len.exact() {
+					(exact as usize, Some(exact as usize))
+				} else {
+					(
+						len.min().map(|min| (min as usize) + 2).unwrap_or(2),
+						len.max().map(|max| (max as usize) + 2),
+					)
+				}
+			}
+
+			Self::Arr(ty, len) => {
+				let (ty_min, ty_max) = ty.size(tydecls, recursed);
+				let len_min = len.min().map(|min| min as usize).unwrap_or(0);
+
+				if let Some(exact) = len.exact() {
+					(ty_min * (exact as usize), ty_max.map(|max| ty_max.unwrap() * max))
+				} else if let Some(len_max) = len.max() {
+					(
+						ty_min * len_min + 2,
+						ty_max.map(|ty_max| ty_max * (len_max as usize) + 2),
+					)
+				} else {
+					(ty_min * len_min + 2, None)
+				}
+			}
+
+			Self::Map(..) => (2, None),
+
+			Self::Opt(ty) => {
+				let (_, ty_max) = ty.size(tydecls, recursed);
+
+				(1, ty_max.map(|ty_max| ty_max + 1))
+			}
+
+			Self::Ref(name) => {
+				if recursed.contains(name) {
+					// 0 is returned here because all valid recursive types are
+					// bounded and all bounded types have their own min size
+					(0, None)
+				} else {
+					recursed.insert(name);
+
+					let tydecl = tydecls.get(name).unwrap();
+
+					tydecl.ty.size(tydecls, recursed)
+				}
+			}
+
+			Self::Enum(enum_ty) => enum_ty.size(tydecls, recursed),
+			Self::Struct(struct_ty) => struct_ty.size(tydecls, recursed),
+
+			Self::Instance(_) => (0, Some(0)),
+
+			Self::Boolean => (1, Some(1)),
+			Self::Color3 => (12, Some(12)),
+			Self::Vector3 => (12, Some(12)),
+			Self::AlignedCFrame => (13, Some(13)),
+			Self::CFrame => (48, Some(48)),
+			Self::Unknown => (0, Some(0)),
 		}
 	}
 }
@@ -141,22 +192,41 @@ pub enum Enum<'src> {
 }
 
 impl<'src> Enum<'src> {
-	pub fn max_size(&self, config: &Config<'src>, recursed: &mut HashSet<&'src str>) -> Option<usize> {
+	pub fn size(
+		&self,
+		tydecls: &HashMap<&'src str, TyDecl<'src>>,
+		recursed: &mut HashSet<&'src str>,
+	) -> (usize, Option<usize>) {
 		match self {
-			Self::Unit(vec) => Some(NumTy::from_f64(0.0, vec.len() as f64).size()),
+			Self::Unit(enumerators) => {
+				let numty = NumTy::from_f64(0.0, enumerators.len() as f64);
+
+				(numty.min() as usize, Some(numty.max() as usize))
+			}
 
 			Self::Tagged { variants, .. } => {
-				let mut size = NumTy::from_f64(0.0, variants.len() as f64).size();
+				let mut min = 0;
+				let mut max = Some(0);
 
-				for (_, ty) in variants {
-					if let Some(ty_size) = ty.max_size(config, recursed) {
-						size += ty_size;
+				for (_, ty) in variants.iter() {
+					let (ty_min, ty_max) = ty.size(tydecls, recursed);
+
+					if ty_min < min {
+						min = ty_min;
+					}
+
+					if let Some(ty_max) = ty_max {
+						if let Some(current_max) = max {
+							if ty_max > current_max {
+								max = Some(ty_max);
+							}
+						}
 					} else {
-						return None;
+						max = None;
 					}
 				}
 
-				Some(size)
+				(min, max)
 			}
 		}
 	}
@@ -168,18 +238,33 @@ pub struct Struct<'src> {
 }
 
 impl<'src> Struct<'src> {
-	pub fn max_size(&self, config: &Config<'src>, recursed: &mut HashSet<&'src str>) -> Option<usize> {
-		let mut size = 0;
+	pub fn size(
+		&self,
+		tydecls: &HashMap<&'src str, TyDecl<'src>>,
+		recursed: &mut HashSet<&'src str>,
+	) -> (usize, Option<usize>) {
+		let mut min = 0;
+		let mut max = Some(0);
 
-		for (_, ty) in &self.fields {
-			if let Some(ty_size) = ty.max_size(config, recursed) {
-				size += ty_size;
+		for (_, ty) in self.fields.iter() {
+			let (ty_min, ty_max) = ty.size(tydecls, recursed);
+
+			if ty_min < min {
+				min = ty_min;
+			}
+
+			if let Some(ty_max) = ty_max {
+				if let Some(current_max) = max {
+					if ty_max > current_max {
+						max = Some(ty_max);
+					}
+				}
 			} else {
-				return None;
+				max = None;
 			}
 		}
 
-		Some(size)
+		(min, max)
 	}
 }
 
@@ -271,6 +356,36 @@ impl NumTy {
 			NumTy::I8 => 1,
 			NumTy::I16 => 2,
 			NumTy::I32 => 4,
+		}
+	}
+
+	pub fn min(&self) -> f64 {
+		match self {
+			NumTy::F32 => f32::MIN.into(),
+			NumTy::F64 => f64::MIN,
+
+			NumTy::U8 => u8::MIN.into(),
+			NumTy::U16 => u16::MIN.into(),
+			NumTy::U32 => u32::MIN.into(),
+
+			NumTy::I8 => i8::MIN.into(),
+			NumTy::I16 => i16::MIN.into(),
+			NumTy::I32 => i32::MIN.into(),
+		}
+	}
+
+	pub fn max(&self) -> f64 {
+		match self {
+			NumTy::F32 => f32::MAX.into(),
+			NumTy::F64 => f64::MAX,
+
+			NumTy::U8 => u8::MAX.into(),
+			NumTy::U16 => u16::MAX.into(),
+			NumTy::U32 => u32::MAX.into(),
+
+			NumTy::I8 => i8::MAX.into(),
+			NumTy::I16 => i16::MAX.into(),
+			NumTy::I32 => i32::MAX.into(),
 		}
 	}
 }

--- a/zap/src/lib.rs
+++ b/zap/src/lib.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 #[derive(Debug)]
 #[cfg(not(target_arch = "wasm32"))]
 pub struct Output {
-	pub path: Option<PathBuf>,
+	pub path: PathBuf,
 	pub code: String,
 	pub defs: Option<String>,
 }
@@ -63,12 +63,12 @@ pub fn run(input: &str) -> Return {
 		Return {
 			code: Some(Code {
 				server: Output {
-					path: config.server_output.map(|p| p.into()),
+					path: config.server_output.into(),
 					code: output::luau::server::code(&config),
 					defs: output::typescript::server::code(&config),
 				},
 				client: Output {
-					path: config.client_output.map(|p| p.into()),
+					path: config.client_output.into(),
 					code: output::luau::client::code(&config),
 					defs: output::typescript::client::code(&config),
 				},

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -1,142 +1,97 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
-use crate::config::{Casing, Config, Enum, EvDecl, NumTy, Range, Struct, Ty, TyDecl};
+use crate::config::{Casing, Config, Enum, EvDecl, EvType, NumTy, Range, Struct, Ty, TyDecl};
 
 use super::{
-	reports::Report,
-	syntax_tree::{
-		Spanned, SyntaxBoolLit, SyntaxConfig, SyntaxDecl, SyntaxEnum, SyntaxEnumKind, SyntaxEvDecl, SyntaxIdentifier,
-		SyntaxNumLit, SyntaxOptValueKind, SyntaxRange, SyntaxRangeKind, SyntaxStrLit, SyntaxStruct, SyntaxTy,
-		SyntaxTyDecl, SyntaxTyKind,
-	},
+	reports::{Report, Span},
+	syntax_tree::*,
 };
 
-pub fn convert(syntax_config: SyntaxConfig<'_>) -> (Config<'_>, Vec<Report>) {
-	let mut state = ConvertState::new(
-		syntax_config
-			.decls
-			.iter()
-			.filter_map(|decl| match decl {
-				SyntaxDecl::Ty(tydecl) => Some(tydecl.name.name),
+struct Converter<'src> {
+	config: SyntaxConfig<'src>,
 
-				_ => None,
-			})
-			.collect(),
-	);
+	tydecls: HashMap<&'src str, SyntaxTyDecl<'src>>,
+	evdecls: HashMap<&'src str, SyntaxEvDecl<'src>>,
 
-	let config = syntax_config.into_config(&mut state);
-
-	(config, state.into_reports())
-}
-
-struct ConvertState<'src> {
 	reports: Vec<Report<'src>>,
-	tydecls: HashSet<&'src str>,
 }
 
-impl<'src> ConvertState<'src> {
-	fn new(tydecls: HashSet<&'src str>) -> Self {
-		Self {
-			reports: Vec::new(),
-			tydecls,
-		}
-	}
+impl<'src> Converter<'src> {
+	fn new(config: SyntaxConfig<'src>) -> Self {
+		let mut tydecls = HashMap::new();
+		let mut evdecls = HashMap::new();
 
-	fn push_report(&mut self, report: Report<'src>) {
-		self.reports.push(report);
-	}
+		for decl in config.decls.iter() {
+			match decl {
+				SyntaxDecl::Ty(tydecl) => {
+					tydecls.insert(tydecl.name.name, tydecl.clone());
+				}
 
-	fn into_reports(self) -> Vec<Report<'src>> {
-		self.reports
-	}
-
-	fn tydecl_exists(&self, name: &'src str) -> bool {
-		self.tydecls.contains(name)
-	}
-}
-
-impl<'src> SyntaxConfig<'src> {
-	fn into_config(self, state: &mut ConvertState<'src>) -> Config<'src> {
-		let mut write_checks = false;
-		let mut typescript = false;
-
-		let mut server_output = None;
-		let mut client_output = None;
-
-		let mut casing = Casing::Pascal;
-
-		for opt in self.opts {
-			match opt.name.into_config() {
-				"write_checks" => match opt.value.kind {
-					SyntaxOptValueKind::Bool(value) => write_checks = value.into_config(),
-
-					_ => state.push_report(Report::AnalyzeInvalidOptValue {
-						span: opt.value.span(),
-						expected: "boolean",
-					}),
-				},
-
-				"typescript" => match opt.value.kind {
-					SyntaxOptValueKind::Bool(value) => typescript = value.into_config(),
-
-					_ => state.push_report(Report::AnalyzeInvalidOptValue {
-						span: opt.value.span(),
-						expected: "boolean",
-					}),
-				},
-
-				"server_output" => match opt.value.kind {
-					SyntaxOptValueKind::Str(value) => server_output = Some(value.into_config()),
-
-					_ => state.push_report(Report::AnalyzeInvalidOptValue {
-						span: opt.value.span(),
-						expected: "string",
-					}),
-				},
-
-				"client_output" => match opt.value.kind {
-					SyntaxOptValueKind::Str(value) => client_output = Some(value.into_config()),
-
-					_ => state.push_report(Report::AnalyzeInvalidOptValue {
-						span: opt.value.span(),
-						expected: "string",
-					}),
-				},
-
-				"casing" => match opt.value.kind {
-					SyntaxOptValueKind::Str(value) => match value.into_config() {
-						"PascalCase" => casing = Casing::Pascal,
-						"camelCase" => casing = Casing::Camel,
-						"snake_case" => casing = Casing::Snake,
-
-						_ => state.push_report(Report::AnalyzeInvalidOptValue {
-							span: opt.value.span(),
-							expected: "`PascalCase`, `camelCase`, or `snake_case`",
-						}),
-					},
-
-					_ => state.push_report(Report::AnalyzeInvalidOptValue {
-						span: opt.value.span(),
-						expected: "`PascalCase`, `camelCase`, or `snake_case`",
-					}),
-				},
-
-				_ => state.push_report(Report::AnalyzeUnknownOptName { span: opt.name.span() }),
+				SyntaxDecl::Ev(evdecl) => {
+					evdecls.insert(evdecl.name.name, evdecl.clone());
+				}
 			}
 		}
 
-		let mut tydecls = Vec::new();
+		Self {
+			config,
+
+			tydecls,
+			evdecls,
+
+			reports: Vec::new(),
+		}
+	}
+
+	fn convert(mut self) -> (Config<'src>, Vec<Report<'src>>) {
+		let config = self.config.clone();
+		let mut tydecls = HashMap::new();
+
+		for tydecl in config.decls.iter().filter_map(|decl| match decl {
+			SyntaxDecl::Ty(tydecl) => Some(tydecl),
+			_ => None,
+		}) {
+			tydecls.insert(tydecl.name.name, self.tydecl(tydecl));
+		}
+
 		let mut evdecls = Vec::new();
 
-		for decl in self.decls {
-			match decl {
-				SyntaxDecl::Ty(tydecl) => tydecls.push(tydecl.into_config(state)),
-				SyntaxDecl::Ev(evdecl) => evdecls.push(evdecl.into_config(state)),
-			}
+		for evdecl in config.decls.iter().filter_map(|decl| match decl {
+			SyntaxDecl::Ev(evdecl) => Some(evdecl),
+			_ => None,
+		}) {
+			evdecls.push(self.evdecl(evdecl, &tydecls));
 		}
 
-		Config {
-			tydecls,
+		if evdecls.is_empty() {
+			self.report(Report::AnalyzeEmptyEvDecls);
+		}
+
+		let write_checks = self.boolean_opt("write_checks", true, &config.opts).0;
+		let typescript = self.boolean_opt("typescript", false, &config.opts).0;
+
+		let server_output = self.str_opt("network/server.lua", "server", &config.opts).0;
+		let client_output = self.str_opt("network/client.lua", "client", &config.opts).0;
+
+		let casing = match self.str_opt("casing", "PascalCase", &config.opts) {
+			("snake_case", ..) => Casing::Snake,
+			("camelCase", ..) => Casing::Camel,
+			("PascalCase", ..) => Casing::Pascal,
+
+			(_, Some(span)) => {
+				self.report(Report::AnalyzeInvalidOptValue {
+					span,
+					expected: "`snake_case`, `camelCase`, or `PascalCase`",
+				});
+
+				Casing::Pascal
+			}
+
+			_ => unreachable!(),
+		};
+
+		let config = Config {
+			tydecls: tydecls.into_values().collect(),
 			evdecls,
 
 			write_checks,
@@ -146,17 +101,100 @@ impl<'src> SyntaxConfig<'src> {
 			client_output,
 
 			casing,
-		}
-	}
-}
+		};
 
-impl<'src> SyntaxEvDecl<'src> {
-	fn into_config(self, state: &mut ConvertState<'src>) -> EvDecl<'src> {
-		let name = self.name.into_config();
-		let from = self.from;
-		let evty = self.evty;
-		let call = self.call;
-		let data = self.data.into_config(state);
+		(config, self.reports)
+	}
+
+	fn boolean_opt(&mut self, name: &'static str, default: bool, opts: &[SyntaxOpt<'src>]) -> (bool, Option<Span>) {
+		let mut value = default;
+		let mut span = None;
+
+		for opt in opts.iter().filter(|opt| opt.name.name == name) {
+			if let SyntaxOptValueKind::Bool(opt_value) = &opt.value.kind {
+				value = opt_value.value;
+				span = Some(opt_value.span());
+			} else {
+				self.report(Report::AnalyzeInvalidOptValue {
+					span: opt.value.span(),
+					expected: "boolean",
+				});
+			}
+		}
+
+		(value, span)
+	}
+
+	fn str_opt(
+		&mut self,
+		name: &'static str,
+		default: &'static str,
+		opts: &[SyntaxOpt<'src>],
+	) -> (&'src str, Option<Span>) {
+		let mut value = default;
+		let mut span = None;
+
+		for opt in opts.iter().filter(|opt| opt.name.name == name) {
+			if let SyntaxOptValueKind::Str(opt_value) = &opt.value.kind {
+				value = self.str(opt_value);
+				span = Some(opt_value.span());
+			} else {
+				self.report(Report::AnalyzeInvalidOptValue {
+					span: opt.value.span(),
+					expected: "string",
+				});
+			}
+		}
+
+		(value, span)
+	}
+
+	#[allow(dead_code)]
+	fn num_opt(&mut self, name: &'static str, default: f64, opts: &[SyntaxOpt<'src>]) -> (f64, Option<Span>) {
+		let mut value = default;
+		let mut span = None;
+
+		for opt in opts.iter().filter(|opt| opt.name.name == name) {
+			if let SyntaxOptValueKind::Num(opt_value) = &opt.value.kind {
+				value = self.num(opt_value);
+				span = Some(opt_value.span());
+			} else {
+				self.report(Report::AnalyzeInvalidOptValue {
+					span: opt.value.span(),
+					expected: "number",
+				});
+			}
+		}
+
+		(value, span)
+	}
+
+	fn evdecl(&mut self, evdecl: &SyntaxEvDecl<'src>, tydecls: &HashMap<&'src str, TyDecl<'src>>) -> EvDecl<'src> {
+		let name = evdecl.name.name;
+		let from = evdecl.from;
+		let evty = evdecl.evty;
+		let call = evdecl.call;
+		let data = self.ty(&evdecl.data);
+
+		if let EvType::Unreliable = evty {
+			let (min, max) = data.size(tydecls, &mut HashSet::new());
+			let event_id_size = NumTy::from_f64(1.0, self.evdecls.len() as f64).size();
+
+			if (min + event_id_size) > 900 {
+				self.report(Report::AnalyzeOversizeUnreliable {
+					ev_span: evdecl.span(),
+					ty_span: evdecl.data.span(),
+					max_size: 900 - event_id_size,
+					size: min,
+				});
+			} else if !max.is_some_and(|max| max < 900 - event_id_size) {
+				self.report(Report::AnalyzePotentiallyOversizeUnreliable {
+					ev_span: evdecl.span(),
+					ty_span: evdecl.data.span(),
+					max_size: 900 - event_id_size,
+				});
+			}
+		}
 
 		EvDecl {
 			name,
@@ -166,211 +204,307 @@ impl<'src> SyntaxEvDecl<'src> {
 			data,
 		}
 	}
-}
 
-impl<'src> SyntaxTyDecl<'src> {
-	fn into_config(self, state: &mut ConvertState<'src>) -> TyDecl<'src> {
-		let name = self.name.into_config();
-		let ty = self.ty.into_config(state);
+	fn tydecl(&mut self, tydecl: &SyntaxTyDecl<'src>) -> TyDecl<'src> {
+		let name = tydecl.name.name;
+		let ty = self.ty(&tydecl.ty);
+
+		if let Some(ref_ty) = self.ty_has_unbounded_ref(name, &tydecl.ty, &mut HashSet::new()) {
+			self.report(Report::AnalyzeUnboundedRecursiveType {
+				decl_span: tydecl.span(),
+				use_span: ref_ty.span(),
+			});
+		}
 
 		TyDecl { name, ty }
 	}
-}
 
-impl<'src> SyntaxTy<'src> {
-	fn into_config(self, state: &mut ConvertState<'src>) -> Ty<'src> {
-		match self.kind {
-			SyntaxTyKind::Num(numty, range) => {
-				let range = range.map(|r| match numty {
-					NumTy::F32 => r.into_config_with_range(state, f32::MIN.into(), f32::MAX.into()),
-					NumTy::F64 => r.into_config_with_range(state, f64::MIN, f64::MAX),
+	fn ty(&mut self, ty: &SyntaxTy<'src>) -> Ty<'src> {
+		match &ty.kind {
+			SyntaxTyKind::Num(numty, range) => Ty::Num(
+				*numty,
+				range
+					.map(|range| self.checked_range_within(&range, numty.min(), numty.max()))
+					.unwrap_or_default(),
+			),
 
-					NumTy::U8 => r.into_config_with_range(state, u8::MIN.into(), u8::MAX.into()),
-					NumTy::U16 => r.into_config_with_range(state, u16::MIN.into(), u16::MAX.into()),
-					NumTy::U32 => r.into_config_with_range(state, u32::MIN.into(), u32::MAX.into()),
+			SyntaxTyKind::Str(len) => Ty::Str(
+				len.map(|range| self.checked_range_within(&range, 0.0, u16::MAX as f64))
+					.unwrap_or_default(),
+			),
 
-					NumTy::I8 => r.into_config_with_range(state, i8::MIN.into(), i8::MAX.into()),
-					NumTy::I16 => r.into_config_with_range(state, i16::MIN.into(), i16::MAX.into()),
-					NumTy::I32 => r.into_config_with_range(state, i32::MIN.into(), i32::MAX.into()),
-				});
+			SyntaxTyKind::Buf(len) => Ty::Buf(
+				len.map(|range| self.checked_range_within(&range, 0.0, u16::MAX as f64))
+					.unwrap_or_default(),
+			),
 
-				Ty::Num(numty, range.unwrap_or_default())
+			SyntaxTyKind::Arr(ty, len) => Ty::Arr(
+				Box::new(self.ty(ty)),
+				len.map(|len| self.checked_range_within(&len, 0.0, u16::MAX as f64))
+					.unwrap_or_default(),
+			),
+
+			SyntaxTyKind::Map(key, val) => {
+				let key_ty = self.ty(key);
+				let val_ty = self.ty(val);
+
+				if let Ty::Opt(_) = key_ty {
+					self.report(Report::AnalyzeInvalidOptionalType {
+						span: (key.span().end - 1)..key.span().end,
+					});
+				}
+
+				if let Ty::Opt(_) = val_ty {
+					self.report(Report::AnalyzeInvalidOptionalType {
+						span: (val.span().end - 1)..val.span().end,
+					});
+				}
+
+				Ty::Map(Box::new(key_ty), Box::new(val_ty))
 			}
 
-			SyntaxTyKind::Str(range) => Ty::Str(
-				range
-					.map(|r| r.into_config_with_range(state, u16::MIN.into(), u16::MAX.into()))
-					.unwrap_or_default(),
-			),
-
-			SyntaxTyKind::Buf(range) => Ty::Buf(
-				range
-					.map(|r| r.into_config_with_range(state, u16::MIN.into(), u16::MAX.into()))
-					.unwrap_or_default(),
-			),
-
-			SyntaxTyKind::Arr(ty, range) => Ty::Arr(
-				Box::new(ty.into_config(state)),
-				range
-					.map(|r| r.into_config_with_range(state, u16::MIN.into(), u16::MAX.into()))
-					.unwrap_or_default(),
-			),
-
-			SyntaxTyKind::Map(key, val) => Ty::Map(Box::new(key.into_config(state)), Box::new(val.into_config(state))),
 			SyntaxTyKind::Opt(ty) => {
-				let ty = ty.into_config(state);
+				let parsed_ty = self.ty(ty);
 
-				if let Ty::Opt(ty) = &ty {
-					if let Ty::Unknown = **ty {
-						state.push_report(Report::AnalyzeInvalidOptionalType {
-							span: (self.end - 1)..self.end,
-						});
-					}
+				if let Ty::Opt(_) = parsed_ty {
+					self.report(Report::AnalyzeInvalidOptionalType {
+						span: (ty.span().end - 1)..ty.span().end,
+					});
 				}
 
-				Ty::Opt(Box::new(ty))
+				Ty::Opt(Box::new(parsed_ty))
 			}
 
-			SyntaxTyKind::Ref(name) => match name.into_config() {
-				"boolean" => Ty::Boolean,
-				"Color3" => Ty::Color3,
-				"Vector3" => Ty::Vector3,
-				"AlignedCFrame" => Ty::AlignedCFrame,
-				"CFrame" => Ty::CFrame,
-				"unknown" => Ty::Opt(Box::new(Ty::Unknown)),
+			SyntaxTyKind::Ref(ref_ty) => {
+				let name = ref_ty.name;
 
-				_ => {
-					let name = name.into_config();
+				match name {
+					"boolean" => Ty::Boolean,
+					"Color3" => Ty::Color3,
+					"Vector3" => Ty::Vector3,
+					"AlignedCFrame" => Ty::AlignedCFrame,
+					"CFrame" => Ty::CFrame,
+					"unknown" => Ty::Opt(Box::new(Ty::Unknown)),
 
-					if !state.tydecl_exists(name) {
-						state.push_report(Report::AnalyzeUnknownTypeRef {
-							span: self.span(),
-							name,
-						});
+					_ => {
+						if self.tydecls.get(name).is_none() {
+							self.report(Report::AnalyzeUnknownTypeRef {
+								span: ref_ty.span(),
+								name,
+							});
+						}
+
+						Ty::Ref(name)
 					}
-
-					Ty::Ref(name)
 				}
-			},
+			}
 
-			SyntaxTyKind::Enum(syntax_enum) => Ty::Enum(syntax_enum.into_config(state)),
-			SyntaxTyKind::Struct(syntax_struct) => Ty::Struct(syntax_struct.into_config(state)),
-			SyntaxTyKind::Instance(name) => Ty::Instance(name.map(|name| name.into_config())),
+			SyntaxTyKind::Enum(enum_ty) => Ty::Enum(self.enum_ty(enum_ty)),
+
+			SyntaxTyKind::Struct(struct_ty) => Ty::Struct(self.struct_ty(struct_ty)),
+
+			SyntaxTyKind::Instance(instance_ty) => Ty::Instance(instance_ty.as_ref().map(|ty| ty.name)),
 		}
 	}
-}
 
-impl<'src> SyntaxEnum<'src> {
-	fn into_config(self, state: &mut ConvertState<'src>) -> Enum<'src> {
-		let span = self.span();
+	fn enum_ty(&mut self, ty: &SyntaxEnum<'src>) -> Enum<'src> {
+		let span = ty.span();
 
-		match self.kind {
+		match &ty.kind {
 			SyntaxEnumKind::Unit(enumerators) => {
 				if enumerators.is_empty() {
-					state.push_report(Report::AnalyzeEmptyEnum { span })
+					self.report(Report::AnalyzeEmptyEnum { span });
 				}
 
-				Enum::Unit(enumerators.into_iter().map(|v| v.into_config()).collect())
+				Enum::Unit(enumerators.iter().map(|e| e.name).collect())
 			}
 
 			SyntaxEnumKind::Tagged { tag, variants } => {
-				if variants.is_empty() {
-					state.push_report(Report::AnalyzeEmptyEnum { span })
-				}
+				let tag_name = tag.value;
 
-				let tag_name = tag.into_config();
+				let variants = variants
+					.iter()
+					.map(|variant| {
+						if variant.1.fields.iter().any(|field| field.0.name == tag_name) {
+							self.report(Report::AnalyzeEnumTagUsed {
+								tag_span: tag.span(),
+								used_span: variant.0.span(),
+								tag: tag_name,
+							});
+						}
+
+						(variant.0.name, self.struct_ty(&variant.1))
+					})
+					.collect();
 
 				Enum::Tagged {
 					tag: tag_name,
-					variants: variants
-						.into_iter()
-						.map(|(name, value)| {
-							if let Some(field) = value.fields.iter().find(|field| field.0.name == tag_name) {
-								state.push_report(Report::AnalyzeEnumTagUsed {
-									tag_span: tag.span(),
-									used_span: field.0.span(),
-									tag: tag_name,
-								});
-							}
-
-							(name.into_config(), value.into_config(state))
-						})
-						.collect(),
+					variants,
 				}
 			}
 		}
 	}
-}
 
-impl<'src> SyntaxStruct<'src> {
-	fn into_config(self, state: &mut ConvertState<'src>) -> Struct<'src> {
+	fn struct_ty(&mut self, ty: &SyntaxStruct<'src>) -> Struct<'src> {
 		let mut fields = Vec::new();
 
-		for field in self.fields {
-			fields.push((field.0.into_config(), field.1.into_config(state)));
+		for field in ty.fields.iter() {
+			fields.push((field.0.name, self.ty(&field.1)));
 		}
 
 		Struct { fields }
 	}
-}
 
-impl<'src> SyntaxRange<'src> {
-	fn into_config(self, state: &mut ConvertState<'src>) -> Range {
-		let range = match self.kind {
-			SyntaxRangeKind::None => Range::new(None, None),
-			SyntaxRangeKind::Exact(num) => Range::new(Some(num.into_config()), Some(num.into_config())),
-			SyntaxRangeKind::WithMin(min) => Range::new(Some(min.into_config()), None),
-			SyntaxRangeKind::WithMax(max) => Range::new(None, Some(max.into_config())),
-			SyntaxRangeKind::WithMinMax(min, max) => Range::new(Some(min.into_config()), Some(max.into_config())),
-		};
+	fn ty_has_unbounded_ref(
+		&self,
+		name: &'src str,
+		ty: &SyntaxTy<'src>,
+		searched: &mut HashSet<&'src str>,
+	) -> Option<SyntaxIdentifier<'src>> {
+		match &ty.kind {
+			SyntaxTyKind::Arr(ty, len) => {
+				let len = len.map(|len| self.range(&len)).unwrap_or_default();
 
-		if range.min().is_some() && range.max().is_some() && range.min().unwrap() > range.max().unwrap() {
-			state.push_report(Report::AnalyzeInvalidRange { span: self.span() });
+				// if array does not have a min size of 0, it is unbounded
+				if len.min().is_some_and(|min| min != 0.0) {
+					self.ty_has_unbounded_ref(name, ty, searched)
+				} else {
+					None
+				}
+			}
+
+			SyntaxTyKind::Ref(ref_ty) => {
+				let ref_name = ref_ty.name;
+
+				match ref_name {
+					ref_name if ref_name == name => Some(*ref_ty),
+
+					"boolean" | "Color3" | "Vector3" | "AlignedCFrame" | "CFrame" | "unknown" => None,
+
+					_ => {
+						if searched.contains(ref_name) {
+							None
+						} else if let Some(tydecl) = self.tydecls.get(ref_name) {
+							searched.insert(ref_name);
+							self.ty_has_unbounded_ref(name, &tydecl.ty, searched)
+						} else {
+							None
+						}
+					}
+				}
+			}
+
+			SyntaxTyKind::Enum(enum_ty) => self.enum_has_unbounded_ref(name, enum_ty, searched),
+			SyntaxTyKind::Struct(struct_ty) => self.struct_has_unbounded_ref(name, struct_ty, searched),
+
+			_ => None,
+		}
+	}
+
+	fn enum_has_unbounded_ref(
+		&self,
+		name: &'src str,
+		ty: &SyntaxEnum<'src>,
+		searched: &mut HashSet<&'src str>,
+	) -> Option<SyntaxIdentifier<'src>> {
+		match &ty.kind {
+			SyntaxEnumKind::Unit { .. } => None,
+
+			SyntaxEnumKind::Tagged { variants, .. } => {
+				for variant in variants.iter() {
+					if let Some(ty) = self.struct_has_unbounded_ref(name, &variant.1, searched) {
+						return Some(ty);
+					}
+				}
+
+				None
+			}
+		}
+	}
+
+	fn struct_has_unbounded_ref(
+		&self,
+		name: &'src str,
+		ty: &SyntaxStruct<'src>,
+		searched: &mut HashSet<&'src str>,
+	) -> Option<SyntaxIdentifier<'src>> {
+		for field in ty.fields.iter() {
+			if let Some(ty) = self.ty_has_unbounded_ref(name, &field.1, searched) {
+				return Some(ty);
+			}
 		}
 
-		range
+		None
 	}
 
-	fn into_config_with_range(self, state: &mut ConvertState<'src>, min: f64, max: f64) -> Range {
-		let range = match self.kind {
-			SyntaxRangeKind::None => Range::new(None, None),
-			SyntaxRangeKind::Exact(num) => Range::new(
-				Some(num.into_config_with_range(state, min, max)),
-				Some(num.into_config_with_range(state, min, max)),
-			),
-			SyntaxRangeKind::WithMin(min_) => Range::new(Some(min_.into_config_with_range(state, min, max)), None),
-			SyntaxRangeKind::WithMax(max_) => Range::new(None, Some(max_.into_config_with_range(state, min, max))),
-			SyntaxRangeKind::WithMinMax(min_, max_) => Range::new(
-				Some(min_.into_config_with_range(state, min, max)),
-				Some(max_.into_config_with_range(state, min, max)),
-			),
-		};
+	fn report(&mut self, report: Report<'src>) {
+		self.reports.push(report);
+	}
 
-		if range.min().is_some() && range.max().is_some() && range.min().unwrap() > range.max().unwrap() {
-			state.push_report(Report::AnalyzeInvalidRange { span: self.span() });
+	fn checked_range_within(&mut self, range: &SyntaxRange<'src>, min: f64, max: f64) -> Range {
+		let value = self.range_within(range, min, max);
+
+		if value.min().is_some() && value.max().is_some() && value.min().unwrap() > value.max().unwrap() {
+			self.report(Report::AnalyzeInvalidRange { span: range.span() });
 		}
 
-		range
-	}
-}
-
-impl<'src> SyntaxStrLit<'src> {
-	fn into_config(self) -> &'src str {
-		self.value.trim_matches('"')
-	}
-}
-
-impl<'src> SyntaxNumLit<'src> {
-	fn into_config(self) -> f64 {
-		self.value.parse().unwrap()
+		value
 	}
 
-	fn into_config_with_range(self, state: &mut ConvertState, min: f64, max: f64) -> f64 {
-		let value = self.into_config();
+	fn range_within(&mut self, range: &SyntaxRange<'src>, min: f64, max: f64) -> Range {
+		match range.kind {
+			SyntaxRangeKind::None => Range::new(None, None),
+
+			SyntaxRangeKind::Exact(num) => {
+				let value = self.num_within(&num, min, max);
+				Range::new(Some(value), Some(value))
+			}
+
+			SyntaxRangeKind::WithMin(min_num) => {
+				let value = self.num_within(&min_num, min, max);
+				Range::new(Some(value), None)
+			}
+
+			SyntaxRangeKind::WithMax(max_num) => {
+				let value = self.num_within(&max_num, min, max);
+				Range::new(None, Some(value))
+			}
+
+			SyntaxRangeKind::WithMinMax(min_num, max_num) => {
+				let min_value = self.num_within(&min_num, min, max);
+				let max_value = self.num_within(&max_num, min, max);
+				Range::new(Some(min_value), Some(max_value))
+			}
+		}
+	}
+
+	#[allow(dead_code)]
+	fn checked_range(&mut self, range: &SyntaxRange<'src>) -> Range {
+		let value = self.range(range);
+
+		if value.min().is_some() && value.max().is_some() && value.min().unwrap() > value.max().unwrap() {
+			self.report(Report::AnalyzeInvalidRange { span: range.span() });
+		}
+
+		value
+	}
+
+	fn range(&self, range: &SyntaxRange<'src>) -> Range {
+		match range.kind {
+			SyntaxRangeKind::None => Range::new(None, None),
+			SyntaxRangeKind::Exact(num) => Range::new(Some(self.num(&num)), Some(self.num(&num))),
+			SyntaxRangeKind::WithMin(min) => Range::new(Some(self.num(&min)), None),
+			SyntaxRangeKind::WithMax(max) => Range::new(None, Some(self.num(&max))),
+			SyntaxRangeKind::WithMinMax(min, max) => Range::new(Some(self.num(&min)), Some(self.num(&max))),
+		}
+	}
+
+	fn num_within(&mut self, num: &SyntaxNumLit<'src>, min: f64, max: f64) -> f64 {
+		let value = self.num(num);
 
 		if value < min || value > max {
-			state.push_report(Report::AnalyzeNumOutsideRange {
-				span: self.span(),
+			self.report(Report::AnalyzeNumOutsideRange {
+				span: num.span(),
 				min,
 				max,
 			});
@@ -378,16 +512,18 @@ impl<'src> SyntaxNumLit<'src> {
 
 		value
 	}
-}
 
-impl SyntaxBoolLit {
-	fn into_config(self) -> bool {
-		self.value
+	fn str(&self, str: &SyntaxStrLit<'src>) -> &'src str {
+		// unwrapping here is safe because the parser already validated the string earlier
+		str.value[1..str.value.len() - 1].as_ref()
+	}
+
+	fn num(&self, num: &SyntaxNumLit<'src>) -> f64 {
+		// unwrapping here is safe because the parser already validated the number earlier
+		num.value.parse().unwrap()
 	}
 }
 
-impl<'src> SyntaxIdentifier<'src> {
-	fn into_config(self) -> &'src str {
-		self.name
-	}
+pub fn convert(config: SyntaxConfig<'_>) -> (Config<'_>, Vec<Report<'_>>) {
+	Converter::new(config).convert()
 }

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -67,11 +67,11 @@ impl<'src> Converter<'src> {
 			self.report(Report::AnalyzeEmptyEvDecls);
 		}
 
-		let write_checks = self.boolean_opt("write_checks", true, &config.opts).0;
-		let typescript = self.boolean_opt("typescript", false, &config.opts).0;
+		let (write_checks, _) = self.boolean_opt("write_checks", true, &config.opts);
+		let (typescript, _) = self.boolean_opt("typescript", false, &config.opts);
 
-		let server_output = self.str_opt("server_output", "network/server.lua", &config.opts).0;
-		let client_output = self.str_opt("client_output", "network/client.lua", &config.opts).0;
+		let (server_output, _) = self.str_opt("server_output", "network/server.lua", &config.opts);
+		let (client_output, _) = self.str_opt("client_output", "network/client.lua", &config.opts);
 
 		let casing = match self.str_opt("casing", "PascalCase", &config.opts) {
 			("snake_case", ..) => Casing::Snake,

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -70,8 +70,8 @@ impl<'src> Converter<'src> {
 		let write_checks = self.boolean_opt("write_checks", true, &config.opts).0;
 		let typescript = self.boolean_opt("typescript", false, &config.opts).0;
 
-		let server_output = self.str_opt("network/server.lua", "server", &config.opts).0;
-		let client_output = self.str_opt("network/client.lua", "client", &config.opts).0;
+		let server_output = self.str_opt("server_output", "network/server.lua", &config.opts).0;
+		let client_output = self.str_opt("client_output", "network/client.lua", &config.opts).0;
 
 		let casing = match self.str_opt("casing", "PascalCase", &config.opts) {
 			("snake_case", ..) => Casing::Snake,

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -67,11 +67,11 @@ impl<'src> Converter<'src> {
 			self.report(Report::AnalyzeEmptyEvDecls);
 		}
 
-		let (write_checks, _) = self.boolean_opt("write_checks", true, &config.opts);
-		let (typescript, _) = self.boolean_opt("typescript", false, &config.opts);
+		let (write_checks, ..) = self.boolean_opt("write_checks", true, &config.opts);
+		let (typescript, ..) = self.boolean_opt("typescript", false, &config.opts);
 
-		let (server_output, _) = self.str_opt("server_output", "network/server.lua", &config.opts);
-		let (client_output, _) = self.str_opt("client_output", "network/client.lua", &config.opts);
+		let (server_output, ..) = self.str_opt("server_output", "network/server.lua", &config.opts);
+		let (client_output, ..) = self.str_opt("client_output", "network/client.lua", &config.opts);
 
 		let casing = match self.str_opt("casing", "PascalCase", &config.opts) {
 			("snake_case", ..) => Casing::Snake,

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -351,8 +351,8 @@ impl<'src> Converter<'src> {
 	fn struct_ty(&mut self, ty: &SyntaxStruct<'src>) -> Struct<'src> {
 		let mut fields = Vec::new();
 
-		for field in ty.fields.iter() {
-			fields.push((field.0.name, self.ty(&field.1)));
+		for (field, ty) in ty.fields.iter() {
+			fields.push((field.name, self.ty(ty)));
 		}
 
 		Struct { fields }

--- a/zap/src/parser/mod.rs
+++ b/zap/src/parser/mod.rs
@@ -1,14 +1,9 @@
-use std::collections::HashSet;
-
 use codespan_reporting::diagnostic::Severity;
 use lalrpop_util::{lalrpop_mod, ParseError};
 
-use crate::config::{Config, EvType};
+use crate::config::Config;
 
-use self::{
-	reports::Report,
-	syntax_tree::{Spanned, SyntaxEvDecl},
-};
+use self::reports::Report;
 
 mod convert;
 mod reports;
@@ -16,50 +11,11 @@ mod syntax_tree;
 
 lalrpop_mod!(pub grammar);
 
-pub fn parse(input: &str) -> (Option<Config<'_>>, Vec<Report>) {
+pub fn parse(input: &str) -> (Option<Config<'_>>, Vec<Report<'_>>) {
 	let parse_result = grammar::ConfigParser::new().parse(input);
 
 	if let Ok(syntax_config) = parse_result {
-		let evdecls: Vec<SyntaxEvDecl<'_>> = syntax_config
-			.decls
-			.iter()
-			.filter_map(|decl| match decl {
-				syntax_tree::SyntaxDecl::Ev(evdecl) => Some(evdecl.clone()),
-				_ => None,
-			})
-			.collect();
-
-		let (config, mut reports) = convert::convert(syntax_config);
-		let max_unreliable_size = 900 - config.event_id_ty().size();
-
-		if config.evdecls.is_empty() {
-			reports.push(Report::AnalyzeEmptyEvDecls);
-		}
-
-		for ev in config.evdecls.iter().filter(|ev| ev.evty == EvType::Unreliable) {
-			let max_size = ev.data.max_size(&config, &mut HashSet::new());
-
-			if let Some(max_size) = max_size {
-				if max_size > max_unreliable_size {
-					let evdecl = evdecls.iter().find(|evdecl| evdecl.name.name == ev.name).unwrap();
-
-					reports.push(Report::AnalyzeOversizeUnreliable {
-						ev_span: evdecl.span(),
-						ty_span: evdecl.data.span(),
-						max_size: max_unreliable_size,
-						size: max_size,
-					});
-				}
-			} else {
-				let evdecl = evdecls.iter().find(|evdecl| evdecl.name.name == ev.name).unwrap();
-
-				reports.push(Report::AnalyzePotentiallyOversizeUnreliable {
-					ev_span: evdecl.span(),
-					ty_span: evdecl.data.span(),
-					max_size: max_unreliable_size,
-				});
-			}
-		}
+		let (config, reports) = convert::convert(syntax_config);
 
 		if reports.iter().any(|report| report.severity() == Severity::Error) {
 			(None, reports)

--- a/zap/src/parser/reports.rs
+++ b/zap/src/parser/reports.rs
@@ -261,7 +261,7 @@ impl<'src> Report<'src> {
 				format!("all unreliable events must be under {max_size} bytes in size"),
 				"consider adding a upper limit to any arrays or strings".to_string(),
 				"upper limits can be added for arrays by doing `[..10]`".to_string(),
-				"upper limits can be added for strings by doing `[..10]`".to_string(),
+				"upper limits can be added for strings by doing `(..10)`".to_string(),
 			]),
 			Self::AnalyzePotentiallyOversizeUnreliable { max_size, .. } => Some(vec![
 				format!("all unreliable events must be under {max_size} bytes in size"),

--- a/zap/src/parser/reports.rs
+++ b/zap/src/parser/reports.rs
@@ -80,6 +80,11 @@ pub enum Report<'src> {
 	AnalyzeInvalidOptionalType {
 		span: Span,
 	},
+
+	AnalyzeUnboundedRecursiveType {
+		decl_span: Span,
+		use_span: Span,
+	},
 }
 
 impl<'src> Report<'src> {
@@ -103,6 +108,7 @@ impl<'src> Report<'src> {
 			Self::AnalyzeUnknownTypeRef { .. } => Severity::Error,
 			Self::AnalyzeNumOutsideRange { .. } => Severity::Error,
 			Self::AnalyzeInvalidOptionalType { .. } => Severity::Error,
+			Self::AnalyzeUnboundedRecursiveType { .. } => Severity::Error,
 		}
 	}
 
@@ -128,7 +134,8 @@ impl<'src> Report<'src> {
 			Self::AnalyzeUnknownOptName { .. } => "unknown opt name".to_string(),
 			Self::AnalyzeUnknownTypeRef { name, .. } => format!("unknown type reference '{}'", name),
 			Self::AnalyzeNumOutsideRange { .. } => "number outside range".to_string(),
-			Self::AnalyzeInvalidOptionalType { .. } => "type must not be optional".to_string(),
+			Self::AnalyzeInvalidOptionalType { .. } => "invalid optional type".to_string(),
+			Self::AnalyzeUnboundedRecursiveType { .. } => "unbounded recursive type".to_string(),
 		}
 	}
 
@@ -152,6 +159,7 @@ impl<'src> Report<'src> {
 			Self::AnalyzeUnknownTypeRef { .. } => "3009",
 			Self::AnalyzeNumOutsideRange { .. } => "3010",
 			Self::AnalyzeInvalidOptionalType { .. } => "3011",
+			Self::AnalyzeUnboundedRecursiveType { .. } => "3012",
 		}
 	}
 
@@ -227,6 +235,15 @@ impl<'src> Report<'src> {
 			Self::AnalyzeInvalidOptionalType { span, .. } => {
 				vec![Label::primary((), span.clone()).with_message("must be removed")]
 			}
+
+			Self::AnalyzeUnboundedRecursiveType {
+				decl_span, use_span, ..
+			} => {
+				vec![
+					Label::primary((), decl_span.clone()).with_message("declared here"),
+					Label::secondary((), use_span.clone()).with_message("used recursively here"),
+				]
+			}
 		}
 	}
 
@@ -273,7 +290,14 @@ impl<'src> Report<'src> {
 				format!("(inclusive) max: {}", max),
 			]),
 			Self::AnalyzeInvalidOptionalType { .. } => Some(vec![
-				"this type can only be used when it is not marked as optional".to_string(),
+				"you cannot have 'double optional' types, where a type is optional twice".to_string(),
+				"maps cannot have optional keys or values, as those are impossible to represent in luau".to_string(),
+				"additionally the `unknown` type cannot be optional".to_string(),
+			]),
+			Self::AnalyzeUnboundedRecursiveType { .. } => Some(vec![
+				"this is an unbounded recursive type".to_string(),
+				"unbounded recursive types are not allowed".to_string(),
+				"unbounded recursive types cause infinite loops".to_string(),
 			]),
 		}
 	}

--- a/zap/src/parser/reports.rs
+++ b/zap/src/parser/reports.rs
@@ -240,8 +240,8 @@ impl<'src> Report<'src> {
 				decl_span, use_span, ..
 			} => {
 				vec![
-					Label::primary((), decl_span.clone()).with_message("declared here"),
-					Label::secondary((), use_span.clone()).with_message("used recursively here"),
+					Label::secondary((), decl_span.clone()).with_message("declared here"),
+					Label::primary((), use_span.clone()).with_message("used recursively here"),
 				]
 			}
 		}

--- a/zap/src/parser/reports.rs
+++ b/zap/src/parser/reports.rs
@@ -296,7 +296,6 @@ impl<'src> Report<'src> {
 			]),
 			Self::AnalyzeUnboundedRecursiveType { .. } => Some(vec![
 				"this is an unbounded recursive type".to_string(),
-				"unbounded recursive types are not allowed".to_string(),
 				"unbounded recursive types cause infinite loops".to_string(),
 			]),
 		}


### PR DESCRIPTION
This PR rewrites all of `convert.rs` and makes some modifications elsewhere. This allows us to properly check unbounded recursive types, get the minimum and maximum size of types for unreliable size checks, and will be easier to work with in the future.