### PR TITLE
Fix typo in optional type example in docs

### DIFF
--- a/docs/config/types.md
+++ b/docs/config/types.md
@@ -224,4 +224,4 @@ The following Roblox Classes are also available as types in Zap:
 ## Optional Types
 
 A type can be made optional by appending a `?` after the **whole type**, such as:
-<CodeBlock code="type Character = Instance (Player)?" />
+<CodeBlock code="type Character = Instance (Model)?" />


### PR DESCRIPTION
Fixes the example character type to be a model instead of a player instance, as characters are models