### PR TITLE
Generate TypeScript semicolons

### DIFF
--- a/zap/src/output/typescript/client.rs
+++ b/zap/src/output/typescript/client.rs
@@ -79,7 +79,7 @@ impl<'src> ClientOutput<'src> {
 				self.push_arg_ty(data);
 			}
 
-			self.push(") => void\n");
+			self.push(") => void;\n");
 
 			self.dedent();
 			self.push_line("};");
@@ -114,7 +114,7 @@ impl<'src> ClientOutput<'src> {
 				self.push_arg_ty(data);
 			}
 
-			self.push(") => void) => () => void\n");
+			self.push(") => void) => () => void;\n");
 
 			self.dedent();
 			self.push_line("};");
@@ -153,7 +153,7 @@ impl<'src> ClientOutput<'src> {
 				self.push(">")
 			}
 
-			self.push("\n");
+			self.push(";\n");
 			self.dedent();
 			self.push_line("};");
 		}

--- a/zap/src/output/typescript/client.rs
+++ b/zap/src/output/typescript/client.rs
@@ -44,7 +44,7 @@ impl<'src> ClientOutput<'src> {
 		self.push_indent();
 		self.push(&format!("type {name} = "));
 		self.push_ty(ty);
-		self.push("\n");
+		self.push(";\n");
 	}
 
 	fn push_tydecls(&mut self) {

--- a/zap/src/output/typescript/mod.rs
+++ b/zap/src/output/typescript/mod.rs
@@ -210,6 +210,6 @@ pub trait Output {
 	fn push_manual_event_loop(&mut self, config: &Config) {
 		let send_events = config.casing.with("SendEvents", "sendEvents", "send_events");
 
-		self.push_line(&format!("export const {send_events}: () => void"))
+		self.push_line(&format!("export const {send_events}: () => void;"))
 	}
 }

--- a/zap/src/output/typescript/server.rs
+++ b/zap/src/output/typescript/server.rs
@@ -44,7 +44,7 @@ impl<'a> ServerOutput<'a> {
 		self.push_indent();
 		self.push(&format!("type {name} = "));
 		self.push_ty(ty);
-		self.push("\n");
+		self.push(";\n");
 	}
 
 	fn push_tydecls(&mut self) {

--- a/zap/src/output/typescript/server.rs
+++ b/zap/src/output/typescript/server.rs
@@ -70,7 +70,7 @@ impl<'a> ServerOutput<'a> {
 			self.push_arg_ty(data);
 		}
 
-		self.push(") => void\n");
+		self.push(") => void;\n");
 	}
 
 	fn push_return_fire_all(&mut self, ev: &EvDecl) {
@@ -85,7 +85,7 @@ impl<'a> ServerOutput<'a> {
 			self.push_arg_ty(data);
 		}
 
-		self.push(") => void\n");
+		self.push(") => void;\n");
 	}
 
 	fn push_return_fire_except(&mut self, ev: &EvDecl) {
@@ -101,7 +101,7 @@ impl<'a> ServerOutput<'a> {
 			self.push_arg_ty(data);
 		}
 
-		self.push(") => void\n");
+		self.push(") => void;\n");
 	}
 
 	fn push_return_fire_list(&mut self, ev: &EvDecl) {
@@ -117,7 +117,7 @@ impl<'a> ServerOutput<'a> {
 			self.push_arg_ty(data);
 		}
 
-		self.push(") => void\n");
+		self.push(") => void;\n");
 	}
 
 	fn push_return_outgoing(&mut self) {
@@ -170,7 +170,7 @@ impl<'a> ServerOutput<'a> {
 				self.push_arg_ty(data);
 			}
 
-			self.push(") => void) => () => void\n");
+			self.push(") => void) => () => void;\n");
 
 			self.dedent();
 			self.push_line("};");
@@ -203,7 +203,7 @@ impl<'a> ServerOutput<'a> {
 				self.push("void");
 			}
 
-			self.push(") => () => void\n");
+			self.push(") => () => void;\n");
 
 			self.dedent();
 			self.push_line("};");


### PR DESCRIPTION
Closes #70.

```ts
// Server generated by Zap v0.6.5 (https://github.com/red-blox/zap)
export const send_events: () => void;
export const MyEvent: {
	fire: (player: Player, value: number) => void;
	fire_all: (value: number) => void;
	fire_except: (except: Player, value: number) => void;
	fire_list: (list: Player[], value: number) => void;
};
export const AnEvent: {
	on: (callback: (player: Player, value: number) => void) => () => void;
};
```