### PR TITLE
Generate TypeScript arrays instead of huge tuples

### DIFF
--- a/config.ebnf
+++ b/config.ebnf
@@ -11,6 +11,7 @@ opt = "opt", (
 	| "server_output", ':', string
 	| "client_output", ':', string
 	| "typescript", ':', ("true" | "false")
+	| "typescript_max_tuple_length", ":", num
 ), [';'];
 
 evdecl = "event", ident, '=', '{',

--- a/docs/config/options.md
+++ b/docs/config/options.md
@@ -144,6 +144,18 @@ Note that Zap uses `RunService.Heartbeat` and a 61 hz rate by default.
 
 <CodeBlock code="opt manual_event_loop = true" />
 
+## `typescript_max_tuple_length`
+
+The maximum non-nested length of tuples Zap can generate, with anything longer generating an array.
+
+### Default
+
+`10`
+
+### Example
+
+<CodeBlock code="opt typescript_max_tuple_length = 5" />
+
 ## `yield_type`
 
 This option changes the way functions yield in zap.

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -11,6 +11,7 @@ pub struct Config<'src> {
 
 	pub write_checks: bool,
 	pub typescript: bool,
+	pub typescript_max_tuple_length: f64,
 	pub manual_event_loop: bool,
 
 	pub server_output: &'src str,

--- a/zap/src/output/typescript/client.rs
+++ b/zap/src/output/typescript/client.rs
@@ -31,7 +31,7 @@ impl<'a> Output for ClientOutput<'a> {
 
 impl<'a> ConfigProvider for ClientOutput<'a> {
 	fn get_config(&self) -> &Config {
-		return self.config;
+		self.config
 	}
 }
 

--- a/zap/src/output/typescript/client.rs
+++ b/zap/src/output/typescript/client.rs
@@ -43,7 +43,7 @@ impl<'src> ClientOutput<'src> {
 
 		self.push_indent();
 		self.push(&format!("type {name} = "));
-		self.push_ty(ty);
+		self.push_ty(ty, self.config);
 		self.push("\n");
 	}
 
@@ -76,7 +76,7 @@ impl<'src> ClientOutput<'src> {
 
 			if let Some(data) = &ev.data {
 				self.push(value);
-				self.push_arg_ty(data);
+				self.push_arg_ty(data, self.config);
 			}
 
 			self.push(") => void\n");
@@ -111,7 +111,7 @@ impl<'src> ClientOutput<'src> {
 
 			if let Some(data) = &ev.data {
 				self.push(value);
-				self.push_arg_ty(data);
+				self.push_arg_ty(data, self.config);
 			}
 
 			self.push(") => void) => () => void\n");
@@ -134,7 +134,7 @@ impl<'src> ClientOutput<'src> {
 
 			if let Some(data) = &fndecl.args {
 				self.push(value);
-				self.push_arg_ty(data);
+				self.push_arg_ty(data, self.config);
 			}
 
 			self.push(") => ");
@@ -144,7 +144,7 @@ impl<'src> ClientOutput<'src> {
 			}
 
 			if let Some(data) = &fndecl.rets {
-				self.push_ty(data);
+				self.push_ty(data, self.config);
 			} else {
 				self.push("void");
 			}

--- a/zap/src/output/typescript/client.rs
+++ b/zap/src/output/typescript/client.rs
@@ -180,7 +180,7 @@ impl<'src> ClientOutput<'src> {
 		};
 
 		if self.config.manual_event_loop {
-			self.push_manual_event_loop(self.config);
+			self.push_manual_event_loop();
 		}
 
 		self.push_tydecls();

--- a/zap/src/output/typescript/client.rs
+++ b/zap/src/output/typescript/client.rs
@@ -1,5 +1,6 @@
 use crate::config::{Config, EvCall, EvSource, Ty, TyDecl, YieldType};
 
+use super::ConfigProvider;
 use super::Output;
 
 struct ClientOutput<'src> {
@@ -28,6 +29,12 @@ impl<'a> Output for ClientOutput<'a> {
 	}
 }
 
+impl<'a> ConfigProvider for ClientOutput<'a> {
+	fn get_config(&self) -> &Config {
+		return self.config;
+	}
+}
+
 impl<'src> ClientOutput<'src> {
 	pub fn new(config: &'src Config<'src>) -> Self {
 		Self {
@@ -43,7 +50,7 @@ impl<'src> ClientOutput<'src> {
 
 		self.push_indent();
 		self.push(&format!("type {name} = "));
-		self.push_ty(ty, self.config);
+		self.push_ty(ty);
 		self.push("\n");
 	}
 
@@ -76,7 +83,7 @@ impl<'src> ClientOutput<'src> {
 
 			if let Some(data) = &ev.data {
 				self.push(value);
-				self.push_arg_ty(data, self.config);
+				self.push_arg_ty(data);
 			}
 
 			self.push(") => void\n");
@@ -111,7 +118,7 @@ impl<'src> ClientOutput<'src> {
 
 			if let Some(data) = &ev.data {
 				self.push(value);
-				self.push_arg_ty(data, self.config);
+				self.push_arg_ty(data);
 			}
 
 			self.push(") => void) => () => void\n");
@@ -134,7 +141,7 @@ impl<'src> ClientOutput<'src> {
 
 			if let Some(data) = &fndecl.args {
 				self.push(value);
-				self.push_arg_ty(data, self.config);
+				self.push_arg_ty(data);
 			}
 
 			self.push(") => ");
@@ -144,7 +151,7 @@ impl<'src> ClientOutput<'src> {
 			}
 
 			if let Some(data) = &fndecl.rets {
-				self.push_ty(data, self.config);
+				self.push_ty(data);
 			} else {
 				self.push("void");
 			}

--- a/zap/src/output/typescript/mod.rs
+++ b/zap/src/output/typescript/mod.rs
@@ -4,7 +4,7 @@ pub mod client;
 pub mod server;
 
 pub trait ConfigProvider {
-    fn get_config(&self) -> &Config;
+	fn get_config(&self) -> &Config;
 }
 
 pub trait Output: ConfigProvider {

--- a/zap/src/output/typescript/mod.rs
+++ b/zap/src/output/typescript/mod.rs
@@ -3,6 +3,8 @@ use crate::config::{Config, Enum, Ty};
 pub mod client;
 pub mod server;
 
+const TUPLE_BECOMES_ARRAY_THRESHOLD: i8 = 11;
+
 pub trait Output {
 	fn push(&mut self, s: &str);
 	fn indent(&mut self);
@@ -24,17 +26,22 @@ pub trait Output {
 			Ty::Arr(ty, range) => match (range.min(), range.max()) {
 				(Some(min), Some(max)) => {
 					if let Some(exact) = range.exact() {
-						self.push("[");
+						if exact >= TUPLE_BECOMES_ARRAY_THRESHOLD.into() {
+							self.push_ty(ty);
+							self.push("[]");
+						} else {
+							self.push("[");
 
-						for i in 0..exact as usize {
-							if i != 0 {
-								self.push(", ");
+							for i in 0..exact as usize {
+								if i != 0 {
+									self.push(", ");
+								}
+
+								self.push_ty(ty);
 							}
 
-							self.push_ty(ty);
+							self.push("]");
 						}
-
-						self.push("]");
 					} else {
 						if min as usize != 0 {
 							self.push("[");

--- a/zap/src/output/typescript/mod.rs
+++ b/zap/src/output/typescript/mod.rs
@@ -216,8 +216,8 @@ pub trait Output: ConfigProvider {
 		));
 	}
 
-	fn push_manual_event_loop(&mut self, config: &Config) {
-		let send_events = config.casing.with("SendEvents", "sendEvents", "send_events");
+	fn push_manual_event_loop(&mut self) {
+		let send_events = self.get_config().casing.with("SendEvents", "sendEvents", "send_events");
 
 		self.push_line(&format!("export const {send_events}: () => void"))
 	}

--- a/zap/src/output/typescript/server.rs
+++ b/zap/src/output/typescript/server.rs
@@ -43,7 +43,7 @@ impl<'a> ServerOutput<'a> {
 
 		self.push_indent();
 		self.push(&format!("type {name} = "));
-		self.push_ty(ty);
+		self.push_ty(ty, self.config);
 		self.push("\n");
 	}
 
@@ -67,7 +67,7 @@ impl<'a> ServerOutput<'a> {
 
 		if let Some(data) = &ev.data {
 			self.push(&format!(", {value}"));
-			self.push_arg_ty(data);
+			self.push_arg_ty(data, self.config);
 		}
 
 		self.push(") => void\n");
@@ -82,7 +82,7 @@ impl<'a> ServerOutput<'a> {
 
 		if let Some(data) = &ev.data {
 			self.push(value);
-			self.push_arg_ty(data);
+			self.push_arg_ty(data, self.config);
 		}
 
 		self.push(") => void\n");
@@ -98,7 +98,7 @@ impl<'a> ServerOutput<'a> {
 
 		if let Some(data) = &ev.data {
 			self.push(&format!(", {value}"));
-			self.push_arg_ty(data);
+			self.push_arg_ty(data, self.config);
 		}
 
 		self.push(") => void\n");
@@ -114,7 +114,7 @@ impl<'a> ServerOutput<'a> {
 
 		if let Some(data) = &ev.data {
 			self.push(&format!(", {value}"));
-			self.push_arg_ty(data);
+			self.push_arg_ty(data, self.config);
 		}
 
 		self.push(") => void\n");
@@ -167,7 +167,7 @@ impl<'a> ServerOutput<'a> {
 
 			if let Some(data) = &ev.data {
 				self.push(&format!(", {value}"));
-				self.push_arg_ty(data);
+				self.push_arg_ty(data, self.config);
 			}
 
 			self.push(") => void) => () => void\n");
@@ -192,13 +192,13 @@ impl<'a> ServerOutput<'a> {
 
 			if let Some(data) = &fndecl.args {
 				self.push(&format!(", {value}"));
-				self.push_arg_ty(data);
+				self.push_arg_ty(data, self.config);
 			}
 
 			self.push(") => ");
 
 			if let Some(data) = &fndecl.rets {
-				self.push_ty(data);
+				self.push_ty(data, self.config);
 			} else {
 				self.push("void");
 			}

--- a/zap/src/output/typescript/server.rs
+++ b/zap/src/output/typescript/server.rs
@@ -1,5 +1,6 @@
 use crate::config::{Config, EvCall, EvDecl, EvSource, Ty, TyDecl};
 
+use super::ConfigProvider;
 use super::Output;
 
 struct ServerOutput<'src> {
@@ -28,6 +29,12 @@ impl<'a> Output for ServerOutput<'a> {
 	}
 }
 
+impl<'a> ConfigProvider for ServerOutput<'a> {
+	fn get_config(&self) -> &Config {
+		return self.config;
+	}
+}
+
 impl<'a> ServerOutput<'a> {
 	pub fn new(config: &'a Config) -> Self {
 		Self {
@@ -43,7 +50,7 @@ impl<'a> ServerOutput<'a> {
 
 		self.push_indent();
 		self.push(&format!("type {name} = "));
-		self.push_ty(ty, self.config);
+		self.push_ty(ty);
 		self.push("\n");
 	}
 
@@ -67,7 +74,7 @@ impl<'a> ServerOutput<'a> {
 
 		if let Some(data) = &ev.data {
 			self.push(&format!(", {value}"));
-			self.push_arg_ty(data, self.config);
+			self.push_arg_ty(data);
 		}
 
 		self.push(") => void\n");
@@ -82,7 +89,7 @@ impl<'a> ServerOutput<'a> {
 
 		if let Some(data) = &ev.data {
 			self.push(value);
-			self.push_arg_ty(data, self.config);
+			self.push_arg_ty(data);
 		}
 
 		self.push(") => void\n");
@@ -98,7 +105,7 @@ impl<'a> ServerOutput<'a> {
 
 		if let Some(data) = &ev.data {
 			self.push(&format!(", {value}"));
-			self.push_arg_ty(data, self.config);
+			self.push_arg_ty(data);
 		}
 
 		self.push(") => void\n");
@@ -114,7 +121,7 @@ impl<'a> ServerOutput<'a> {
 
 		if let Some(data) = &ev.data {
 			self.push(&format!(", {value}"));
-			self.push_arg_ty(data, self.config);
+			self.push_arg_ty(data);
 		}
 
 		self.push(") => void\n");
@@ -167,7 +174,7 @@ impl<'a> ServerOutput<'a> {
 
 			if let Some(data) = &ev.data {
 				self.push(&format!(", {value}"));
-				self.push_arg_ty(data, self.config);
+				self.push_arg_ty(data);
 			}
 
 			self.push(") => void) => () => void\n");
@@ -192,13 +199,13 @@ impl<'a> ServerOutput<'a> {
 
 			if let Some(data) = &fndecl.args {
 				self.push(&format!(", {value}"));
-				self.push_arg_ty(data, self.config);
+				self.push_arg_ty(data);
 			}
 
 			self.push(") => ");
 
 			if let Some(data) = &fndecl.rets {
-				self.push_ty(data, self.config);
+				self.push_ty(data);
 			} else {
 				self.push("void");
 			}

--- a/zap/src/output/typescript/server.rs
+++ b/zap/src/output/typescript/server.rs
@@ -231,7 +231,7 @@ impl<'a> ServerOutput<'a> {
 		};
 
 		if self.config.manual_event_loop {
-			self.push_manual_event_loop(self.config);
+			self.push_manual_event_loop();
 		}
 
 		self.push_tydecls();

--- a/zap/src/output/typescript/server.rs
+++ b/zap/src/output/typescript/server.rs
@@ -31,7 +31,7 @@ impl<'a> Output for ServerOutput<'a> {
 
 impl<'a> ConfigProvider for ServerOutput<'a> {
 	fn get_config(&self) -> &Config {
-		return self.config;
+		self.config
 	}
 }
 

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -88,7 +88,7 @@ impl<'src> Converter<'src> {
 		let (write_checks, ..) = self.boolean_opt("write_checks", true, &config.opts);
 		let (typescript, ..) = self.boolean_opt("typescript", false, &config.opts);
 		let (manual_event_loop, ..) = self.boolean_opt("manual_event_loop", false, &config.opts);
-		let (typescript_max_tuple_length, ..) = self.num_opt("typescript_max_tuple_length", 11.0, &config.opts);
+		let (typescript_max_tuple_length, ..) = self.num_opt("typescript_max_tuple_length", 10.0, &config.opts);
 
 		let (server_output, ..) = self.str_opt("server_output", "network/server.lua", &config.opts);
 		let (client_output, ..) = self.str_opt("client_output", "network/client.lua", &config.opts);

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -88,6 +88,7 @@ impl<'src> Converter<'src> {
 		let (write_checks, ..) = self.boolean_opt("write_checks", true, &config.opts);
 		let (typescript, ..) = self.boolean_opt("typescript", false, &config.opts);
 		let (manual_event_loop, ..) = self.boolean_opt("manual_event_loop", false, &config.opts);
+		let (typescript_max_tuple_length, ..) = self.num_opt("typescript_max_tuple_length", 11.0, &config.opts);
 
 		let (server_output, ..) = self.str_opt("server_output", "network/server.lua", &config.opts);
 		let (client_output, ..) = self.str_opt("client_output", "network/client.lua", &config.opts);
@@ -103,6 +104,7 @@ impl<'src> Converter<'src> {
 
 			write_checks,
 			typescript,
+			typescript_max_tuple_length,
 			manual_event_loop,
 
 			server_output,
@@ -231,7 +233,6 @@ impl<'src> Converter<'src> {
 		(value, span)
 	}
 
-	#[allow(dead_code)]
 	fn num_opt(&mut self, name: &'static str, default: f64, opts: &[SyntaxOpt<'src>]) -> (f64, Option<Span>) {
 		let mut value = default;
 		let mut span = None;


### PR DESCRIPTION
Closes #69.

This doesn't have special behavior for nested types like `u8[10][10][10][10]` to keep this uncontroversial.

Constant `const TUPLE_BECOMES_ARRAY_THRESHOLD: i8 = 11;` specifies the threshold. Alternatively there could be a configuration option for this.