### PR TITLE
Fix nested arrays

### DIFF
--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -113,14 +113,18 @@ impl Des {
 			Ty::Arr(ty, range) => {
 				self.push_assign(into.clone(), Expr::EmptyTable);
 
+				let escaped = into.display_escaped();
+				let suffix = &escaped[escaped.find('_').unwrap()..];
+				let index_name = "i".to_string() + suffix;
+
 				if let Some(len) = range.exact() {
 					self.push_stmt(Stmt::NumFor {
-						var: "i",
+						var: index_name.clone().leak(),
 						from: 1.0.into(),
 						to: len.into(),
 					});
 
-					self.push_ty(ty, into.clone().eindex("i".into()));
+					self.push_ty(ty, into.clone().eindex(index_name.as_str().into()));
 					self.push_stmt(Stmt::End);
 				} else {
 					self.push_local("len", Some(self.readnumty(NumTy::U16)));
@@ -130,7 +134,7 @@ impl Des {
 					}
 
 					self.push_stmt(Stmt::NumFor {
-						var: "i",
+						var: index_name.clone().leak(),
 						from: 1.0.into(),
 						to: "len".into(),
 					});
@@ -140,7 +144,7 @@ impl Des {
 
 					self.push_ty(ty, Var::Name(var_name.clone()));
 
-					self.push_stmt(Stmt::Assign(into.eindex("i".into()), Var::Name(var_name).into()));
+					self.push_stmt(Stmt::Assign(into.eindex(index_name.as_str().into()), Var::Name(var_name).into()));
 
 					self.push_stmt(Stmt::End);
 				}

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -294,11 +294,17 @@ impl Var {
 		Expr::Call(Box::new(self), None, args)
 	}
 
-	pub fn display_escaped(&self) -> String {
+	pub fn display_escaped_suffix(&self) -> i32 {
 		match self {
-			Self::Name(name) => format!("{}_v", name),
-			Self::NameIndex(var, index) => format!("{}_{}_v", var.display_escaped(), index),
-			Self::ExprIndex(var, index) => format!("{}_{}_v", var.display_escaped(), index),
+			Self::Name(name) => match name.find('_') {
+				Some(underscore_index) => match name[underscore_index + 1..].parse::<i32>() {
+					Ok(number) => number + 1,
+					Err(_) => 0,
+				},
+				None => 0,
+			},
+			Self::NameIndex(var, _) => var.display_escaped_suffix() + 1,
+			Self::ExprIndex(var, _) => var.display_escaped_suffix() + 1,
 		}
 	}
 }

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -121,18 +121,22 @@ impl Ser {
 			}
 
 			Ty::Arr(ty, range) => {
+				let escaped = from.display_escaped();
+				let suffix = &escaped[escaped.find('_').unwrap()..];
+				let index_name = "i".to_string() + suffix;
+
 				if let Some(len) = range.exact() {
 					if self.checks {
 						self.push_assert(from_expr.clone().len().eq(len.into()), None);
 					}
 
 					self.push_stmt(Stmt::NumFor {
-						var: "i",
+						var: index_name.clone().leak(),
 						from: 1.0.into(),
 						to: len.into(),
 					});
 
-					self.push_ty(ty, from.clone().eindex("i".into()));
+					self.push_ty(ty, from.clone().eindex(index_name.as_str().into()));
 					self.push_stmt(Stmt::End);
 				} else {
 					self.push_local("len", Some(from_expr.clone().len()));
@@ -144,7 +148,7 @@ impl Ser {
 					self.push_writeu16("len".into());
 
 					self.push_stmt(Stmt::NumFor {
-						var: "i",
+						var: index_name.clone().leak(),
 						from: 1.0.into(),
 						to: "len".into(),
 					});
@@ -153,7 +157,7 @@ impl Ser {
 
 					self.push_stmt(Stmt::Local(
 						var_name.clone().leak(),
-						Some(from.clone().eindex("i".into()).into()),
+						Some(from.clone().eindex(index_name.as_str().into()).into()),
 					));
 
 					self.push_ty(ty, Var::Name(var_name));

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -121,9 +121,7 @@ impl Ser {
 			}
 
 			Ty::Arr(ty, range) => {
-				let escaped = from.display_escaped();
-				let suffix = &escaped[escaped.find('_').unwrap()..];
-				let index_name = "i".to_string() + suffix;
+				let var_name = format!("i_{}", from.display_escaped_suffix() + 1);
 
 				if let Some(len) = range.exact() {
 					if self.checks {
@@ -131,12 +129,12 @@ impl Ser {
 					}
 
 					self.push_stmt(Stmt::NumFor {
-						var: index_name.clone().leak(),
+						var: var_name.clone().leak(),
 						from: 1.0.into(),
 						to: len.into(),
 					});
 
-					self.push_ty(ty, from.clone().eindex(index_name.as_str().into()));
+					self.push_ty(ty, from.clone().eindex(var_name.as_str().into()));
 					self.push_stmt(Stmt::End);
 				} else {
 					self.push_local("len", Some(from_expr.clone().len()));
@@ -148,16 +146,14 @@ impl Ser {
 					self.push_writeu16("len".into());
 
 					self.push_stmt(Stmt::NumFor {
-						var: index_name.clone().leak(),
+						var: var_name.clone().leak(),
 						from: 1.0.into(),
 						to: "len".into(),
 					});
 
-					let var_name = from.display_escaped();
-
 					self.push_stmt(Stmt::Local(
 						var_name.clone().leak(),
-						Some(from.clone().eindex(index_name.as_str().into()).into()),
+						Some(from.clone().eindex(var_name.as_str().into()).into()),
 					));
 
 					self.push_ty(ty, Var::Name(var_name));


### PR DESCRIPTION
Allows for types like this:
```
event test = {
	from: Client,
	type: Reliable,
	call: ManyAsync,
	data: u8[10][20][2][2],
}
```
Clearly the generated code should be cleaner, `i_v_i_v_v_i_v_i_v_v_v_i_v_i_v_v_i_v_i_v_v_v_v` is absolutely not an acceptable variable name long-term, this is only meant as a temporary fix.

Before (`i` shadowing breaks code):
```luau
local returns = {
	test = {
		fire = function(value: ({ ({ ({ ({ (number) }) }) }) }))
			alloc(1)
			buffer.writeu8(outgoing_buff, outgoing_apos, 1)
			assert(#value == 2)
			for i = 1, 2 do
				assert(#value[i] == 2)
				for i = 1, 2 do
					assert(#value[i][i] == 20)
					for i = 1, 20 do
						assert(#value[i][i][i] == 10)
						for i = 1, 10 do
							alloc(1)
							buffer.writeu8(outgoing_buff, outgoing_apos, value[i][i][i][i])
						end
					end
				end
			end
		end,
	},
}
```
After:
```luau
local returns = {
	test = {
		fire = function(value: ({ ({ ({ ({ (number) }) }) }) }))
			alloc(1)
			buffer.writeu8(outgoing_buff, outgoing_apos, 1)
			assert(#value == 2)
			for i_v = 1, 2 do
				assert(#value[i_v] == 2)
				for i_v_i_v_v = 1, 2 do
					assert(#value[i_v][i_v_i_v_v] == 20)
					for i_v_i_v_v_i_v_i_v_v_v = 1, 20 do
						assert(#value[i_v][i_v_i_v_v][i_v_i_v_v_i_v_i_v_v_v] == 10)
						for i_v_i_v_v_i_v_i_v_v_v_i_v_i_v_v_i_v_i_v_v_v_v = 1, 10 do
							alloc(1)
							buffer.writeu8(outgoing_buff, outgoing_apos, value[i_v][i_v_i_v_v][i_v_i_v_v_i_v_i_v_v_v][i_v_i_v_v_i_v_i_v_v_v_i_v_i_v_v_i_v_i_v_v_v_v])
						end
					end
				end
			end
		end,
	},
}
```