### PR TITLE
Freeze module returns

### DIFF
--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -576,7 +576,7 @@ impl<'src> ClientOutput<'src> {
 			.iter()
 			.filter(|ev_decl| ev_decl.from == EvSource::Client)
 		{
-			self.push_line(&format!("{name} = {{", name = ev.name));
+			self.push_line(&format!("{name} = table.freeze {{", name = ev.name));
 			self.indent();
 
 			self.push_return_fire(ev);

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -61,7 +61,7 @@ impl<'src> ClientOutput<'src> {
 		}
 
 		for ev in self.config.evdecls.iter() {
-			self.push_line(&format!("{name} = table.freeze {{", name = ev.name));
+			self.push_line(&format!("{name} = table.freeze({{", name = ev.name));
 			self.indent();
 
 			if ev.from == EvSource::Client {
@@ -74,17 +74,17 @@ impl<'src> ClientOutput<'src> {
 			}
 
 			self.dedent();
-			self.push_line("},");
+			self.push_line("}),");
 		}
 
 		for fndecl in self.config.fndecls.iter() {
-			self.push_line(&format!("{name} = table.freeze {{", name = fndecl.name));
+			self.push_line(&format!("{name} = table.freeze({{", name = fndecl.name));
 			self.indent();
 
 			self.push_line(&format!("{call} = noop"));
 
 			self.dedent();
-			self.push_line("},");
+			self.push_line("}),");
 		}
 
 		self.dedent();
@@ -576,13 +576,13 @@ impl<'src> ClientOutput<'src> {
 			.iter()
 			.filter(|ev_decl| ev_decl.from == EvSource::Client)
 		{
-			self.push_line(&format!("{name} = table.freeze {{", name = ev.name));
+			self.push_line(&format!("{name} = table.freeze({{", name = ev.name));
 			self.indent();
 
 			self.push_return_fire(ev);
 
 			self.dedent();
-			self.push_line("},");
+			self.push_line("}),");
 		}
 	}
 
@@ -715,7 +715,7 @@ impl<'src> ClientOutput<'src> {
 			.iter()
 			.filter(|ev_decl| ev_decl.from == EvSource::Server)
 		{
-			self.push_line(&format!("{name} = table.freeze {{", name = ev.name));
+			self.push_line(&format!("{name} = table.freeze({{", name = ev.name));
 			self.indent();
 
 			match ev.call {
@@ -724,7 +724,7 @@ impl<'src> ClientOutput<'src> {
 			}
 
 			self.dedent();
-			self.push_line("},");
+			self.push_line("}),");
 		}
 	}
 
@@ -735,7 +735,7 @@ impl<'src> ClientOutput<'src> {
 		for fndecl in self.config.fndecls.iter() {
 			let id = fndecl.id;
 
-			self.push_line(&format!("{name} = table.freeze {{", name = fndecl.name));
+			self.push_line(&format!("{name} = table.freeze({{", name = fndecl.name));
 			self.indent();
 
 			self.push_indent();
@@ -803,12 +803,12 @@ impl<'src> ClientOutput<'src> {
 			self.push_line("end,");
 
 			self.dedent();
-			self.push_line("},");
+			self.push_line("}),");
 		}
 	}
 
 	pub fn push_return(&mut self) {
-		self.push_line("local returns = table.freeze {");
+		self.push_line("local returns = table.freeze({");
 		self.indent();
 
 		if self.config.manual_event_loop {
@@ -822,7 +822,7 @@ impl<'src> ClientOutput<'src> {
 		self.push_return_functions();
 
 		self.dedent();
-		self.push_line("}");
+		self.push_line("})");
 
 		self.push_line("type Events = typeof(returns)");
 		self.push_line("return returns");

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -46,7 +46,7 @@ impl<'src> ClientOutput<'src> {
 
 		self.push_line("local noop = function() end");
 
-		self.push_line("return {");
+		self.push_line("return table.freeze({");
 		self.indent();
 
 		let fire = self.config.casing.with("Fire", "fire", "fire");
@@ -61,7 +61,7 @@ impl<'src> ClientOutput<'src> {
 		}
 
 		for ev in self.config.evdecls.iter() {
-			self.push_line(&format!("{name} = {{", name = ev.name));
+			self.push_line(&format!("{name} = table.freeze {{", name = ev.name));
 			self.indent();
 
 			if ev.from == EvSource::Client {
@@ -78,7 +78,7 @@ impl<'src> ClientOutput<'src> {
 		}
 
 		for fndecl in self.config.fndecls.iter() {
-			self.push_line(&format!("{name} = {{", name = fndecl.name));
+			self.push_line(&format!("{name} = table.freeze {{", name = fndecl.name));
 			self.indent();
 
 			self.push_line(&format!("{call} = noop"));
@@ -88,7 +88,7 @@ impl<'src> ClientOutput<'src> {
 		}
 
 		self.dedent();
-		self.push_line("} :: Events");
+		self.push_line("} :: Events)");
 
 		self.dedent();
 		self.push_line("end");
@@ -715,7 +715,7 @@ impl<'src> ClientOutput<'src> {
 			.iter()
 			.filter(|ev_decl| ev_decl.from == EvSource::Server)
 		{
-			self.push_line(&format!("{name} = {{", name = ev.name));
+			self.push_line(&format!("{name} = table.freeze {{", name = ev.name));
 			self.indent();
 
 			match ev.call {
@@ -735,7 +735,7 @@ impl<'src> ClientOutput<'src> {
 		for fndecl in self.config.fndecls.iter() {
 			let id = fndecl.id;
 
-			self.push_line(&format!("{name} = {{", name = fndecl.name));
+			self.push_line(&format!("{name} = table.freeze {{", name = fndecl.name));
 			self.indent();
 
 			self.push_indent();
@@ -808,7 +808,7 @@ impl<'src> ClientOutput<'src> {
 	}
 
 	pub fn push_return(&mut self) {
-		self.push_line("local returns = {");
+		self.push_line("local returns = table.freeze {");
 		self.indent();
 
 		if self.config.manual_event_loop {

--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -46,7 +46,7 @@ impl<'a> ServerOutput<'a> {
 
 		self.push_line("local noop = function() end");
 
-		self.push_line("return {");
+		self.push_line("return table.freeze({");
 		self.indent();
 
 		let fire = self.config.casing.with("Fire", "fire", "fire");
@@ -64,7 +64,7 @@ impl<'a> ServerOutput<'a> {
 		}
 
 		for ev in self.config.evdecls.iter() {
-			self.push_line(&format!("{name} = {{", name = ev.name));
+			self.push_line(&format!("{name} = table.freeze {{", name = ev.name));
 			self.indent();
 
 			if ev.from == EvSource::Client {
@@ -84,7 +84,7 @@ impl<'a> ServerOutput<'a> {
 		}
 
 		for fndecl in self.config.fndecls.iter() {
-			self.push_line(&format!("{name} = {{", name = fndecl.name));
+			self.push_line(&format!("{name} = table.freeze {{", name = fndecl.name));
 			self.indent();
 
 			self.push_line(&format!("{set_callback} = noop"));
@@ -94,7 +94,7 @@ impl<'a> ServerOutput<'a> {
 		}
 
 		self.dedent();
-		self.push_line("} :: Events");
+		self.push_line("} :: Events)");
 
 		self.dedent();
 		self.push_line("end");
@@ -776,7 +776,7 @@ impl<'a> ServerOutput<'a> {
 			.iter()
 			.filter(|ev_decl| ev_decl.from == EvSource::Client)
 		{
-			self.push_line(&format!("{} = {{", ev.name));
+			self.push_line(&format!("{} = table.freeze {{", ev.name));
 			self.indent();
 
 			match ev.call {
@@ -789,7 +789,7 @@ impl<'a> ServerOutput<'a> {
 		}
 
 		for fndecl in self.config.fndecls.iter() {
-			self.push_line(&format!("{} = {{", fndecl.name));
+			self.push_line(&format!("{} = table.freeze {{", fndecl.name));
 			self.indent();
 
 			self.push_fn_return(fndecl);
@@ -800,7 +800,7 @@ impl<'a> ServerOutput<'a> {
 	}
 
 	pub fn push_return(&mut self) {
-		self.push_line("local returns = {");
+		self.push_line("local returns = table.freeze {");
 		self.indent();
 
 		if self.config.manual_event_loop {

--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -655,7 +655,7 @@ impl<'a> ServerOutput<'a> {
 			.iter()
 			.filter(|ev_decl| ev_decl.from == EvSource::Server)
 		{
-			self.push_line(&format!("{name} = {{", name = ev.name));
+			self.push_line(&format!("{name} = table.freeze {{", name = ev.name));
 			self.indent();
 
 			self.push_return_fire(ev);

--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -64,7 +64,7 @@ impl<'a> ServerOutput<'a> {
 		}
 
 		for ev in self.config.evdecls.iter() {
-			self.push_line(&format!("{name} = table.freeze {{", name = ev.name));
+			self.push_line(&format!("{name} = table.freeze({{", name = ev.name));
 			self.indent();
 
 			if ev.from == EvSource::Client {
@@ -80,17 +80,17 @@ impl<'a> ServerOutput<'a> {
 			}
 
 			self.dedent();
-			self.push_line("},");
+			self.push_line("}),");
 		}
 
 		for fndecl in self.config.fndecls.iter() {
-			self.push_line(&format!("{name} = table.freeze {{", name = fndecl.name));
+			self.push_line(&format!("{name} = table.freeze({{", name = fndecl.name));
 			self.indent();
 
 			self.push_line(&format!("{set_callback} = noop"));
 
 			self.dedent();
-			self.push_line("},");
+			self.push_line("}),");
 		}
 
 		self.dedent();
@@ -655,7 +655,7 @@ impl<'a> ServerOutput<'a> {
 			.iter()
 			.filter(|ev_decl| ev_decl.from == EvSource::Server)
 		{
-			self.push_line(&format!("{name} = table.freeze {{", name = ev.name));
+			self.push_line(&format!("{name} = table.freeze({{", name = ev.name));
 			self.indent();
 
 			self.push_return_fire(ev);
@@ -664,7 +664,7 @@ impl<'a> ServerOutput<'a> {
 			self.push_return_fire_list(ev);
 
 			self.dedent();
-			self.push_line("},");
+			self.push_line("}),");
 		}
 	}
 
@@ -776,7 +776,7 @@ impl<'a> ServerOutput<'a> {
 			.iter()
 			.filter(|ev_decl| ev_decl.from == EvSource::Client)
 		{
-			self.push_line(&format!("{} = table.freeze {{", ev.name));
+			self.push_line(&format!("{} = table.freeze({{", ev.name));
 			self.indent();
 
 			match ev.call {
@@ -785,22 +785,22 @@ impl<'a> ServerOutput<'a> {
 			}
 
 			self.dedent();
-			self.push_line("},");
+			self.push_line("}),");
 		}
 
 		for fndecl in self.config.fndecls.iter() {
-			self.push_line(&format!("{} = table.freeze {{", fndecl.name));
+			self.push_line(&format!("{} = table.freeze({{", fndecl.name));
 			self.indent();
 
 			self.push_fn_return(fndecl);
 
 			self.dedent();
-			self.push_line("},");
+			self.push_line("}),");
 		}
 	}
 
 	pub fn push_return(&mut self) {
-		self.push_line("local returns = table.freeze {");
+		self.push_line("local returns = table.freeze({");
 		self.indent();
 
 		if self.config.manual_event_loop {
@@ -813,7 +813,7 @@ impl<'a> ServerOutput<'a> {
 		self.push_return_listen();
 
 		self.dedent();
-		self.push_line("}");
+		self.push_line("})");
 
 		self.push_line("type Events = typeof(returns)");
 		self.push_line("return returns");


### PR DESCRIPTION
Makes the return table of the generated modules frozen, including the nested tables for events