### PR TITLE
Add DateTime types

### DIFF
--- a/docs/config/types.md
+++ b/docs/config/types.md
@@ -215,11 +215,16 @@ local CFrameSpecialCases = {
 }
 ```
 
+## DateTimes
+
+Zap supports sending DateTimes. There are two types of DateTime you may send - a regular `DateTime`, and `DateTimeMillis`.
+DateTime sends the UnixTimestamp property of the DateTime object, with DateTimeMillis sending the UnixTimestampMillis property of the DateTime object.
+
 ## Other Roblox Classes
 
 The following Roblox Classes are also available as types in Zap:
 
-- `Vector3`
+- `Vector3`, `Color3`
 
 ## Optional Types
 

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -127,6 +127,8 @@ pub enum Ty<'src> {
 	Struct(Struct<'src>),
 	Instance(Option<&'src str>),
 
+	DateTimeMillis,
+	DateTime,
 	Color3,
 	Vector3,
 	AlignedCFrame,
@@ -214,6 +216,8 @@ impl<'src> Ty<'src> {
 
 			Self::Instance(_) => (4, Some(4)),
 
+			Self::DateTimeMillis => (8, Some(8)),
+			Self::DateTime => (8, Some(8)),
 			Self::Boolean => (1, Some(1)),
 			Self::Color3 => (12, Some(12)),
 			Self::Vector3 => (12, Some(12)),

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -264,12 +264,20 @@ impl Des {
 
 			Ty::DateTimeMillis => self.push_assign(
 				into,
-				Expr::Call(Box::new(Var::from("DateTime").nindex("fromUnixTimestampMillis")), None, vec![self.readf64()]),
+				Expr::Call(
+					Box::new(Var::from("DateTime").nindex("fromUnixTimestampMillis")),
+					None,
+					vec![self.readf64()],
+				),
 			),
 
 			Ty::DateTime => self.push_assign(
 				into,
-				Expr::Call(Box::new(Var::from("DateTime").nindex("fromUnixTimestamp")), None, vec![self.readf64()]),
+				Expr::Call(
+					Box::new(Var::from("DateTime").nindex("fromUnixTimestamp")),
+					None,
+					vec![self.readf64()],
+				),
 			),
 
 			Ty::Boolean => self.push_assign(into, self.readu8().eq(1.0.into())),

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -262,6 +262,16 @@ impl Des {
 			// unknown is always an opt
 			Ty::Unknown => unreachable!(),
 
+			Ty::DateTimeMillis => self.push_assign(
+				into,
+				Expr::Call(Box::new(Var::from("DateTime").nindex("fromUnixTimestampMillis")), None, vec![self.readf64()]),
+			),
+
+			Ty::DateTime => self.push_assign(
+				into,
+				Expr::Call(Box::new(Var::from("DateTime").nindex("fromUnixTimestamp")), None, vec![self.readf64()]),
+			),
+
 			Ty::Boolean => self.push_assign(into, self.readu8().eq(1.0.into())),
 			Ty::Color3 => self.push_assign(
 				into,

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -246,6 +246,9 @@ impl Ser {
 				));
 			}
 
+			Ty::DateTimeMillis => self.push_writef64(from.clone().nindex("UnixTimestampMillis").into()),
+			Ty::DateTime => self.push_writef64(from.clone().nindex("UnixTimestamp").into()),
+
 			Ty::Vector3 => {
 				self.push_writef32(from.clone().nindex("X").into());
 				self.push_writef32(from.clone().nindex("Y").into());

--- a/zap/src/output/luau/mod.rs
+++ b/zap/src/output/luau/mod.rs
@@ -171,6 +171,8 @@ pub trait Output {
 
 			Ty::Instance(name) => self.push(name.unwrap_or("Instance")),
 
+			Ty::DateTimeMillis => self.push("DateTime"),
+			Ty::DateTime => self.push("DateTime"),
 			Ty::Unknown => self.push("unknown"),
 			Ty::Boolean => self.push("boolean"),
 			Ty::Color3 => self.push("Color3"),

--- a/zap/src/output/typescript/mod.rs
+++ b/zap/src/output/typescript/mod.rs
@@ -176,6 +176,8 @@ pub trait Output {
 
 			Ty::Instance(name) => self.push(name.unwrap_or("Instance")),
 
+			Ty::DateTimeMillis => self.push("DateTime"),
+			Ty::DateTime => self.push("DateTime"),
 			Ty::Unknown => self.push("unknown"),
 			Ty::Boolean => self.push("boolean"),
 			Ty::Color3 => self.push("Color3"),

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -414,6 +414,8 @@ impl<'src> Converter<'src> {
 				let name = ref_ty.name;
 
 				match name {
+					"DateTimeMillis" => Ty::DateTimeMillis,
+					"DateTime" => Ty::DateTime,
 					"boolean" => Ty::Boolean,
 					"Color3" => Ty::Color3,
 					"Vector3" => Ty::Vector3,


### PR DESCRIPTION
Adds in DateTime and DateTimeMillis as types, with DateTime sending the UnixTimestamp property of the DateTime object, and DateTimeMillis sending the UnixTimestampMillis property of the DateTime object.