### PR TITLE
Add BrickColor type

### DIFF
--- a/docs/config/types.md
+++ b/docs/config/types.md
@@ -219,7 +219,7 @@ local CFrameSpecialCases = {
 
 The following Roblox Classes are also available as types in Zap:
 
-- `Vector3`, `Color3`, `Brickcolor`
+- `Vector3`, `Color3`, `BrickColor`
 
 ## Optional Types
 

--- a/docs/config/types.md
+++ b/docs/config/types.md
@@ -219,7 +219,7 @@ local CFrameSpecialCases = {
 
 The following Roblox Classes are also available as types in Zap:
 
-- `Vector3`
+- `Vector3`, `Color3`, `Brickcolor`
 
 ## Optional Types
 

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -127,6 +127,7 @@ pub enum Ty<'src> {
 	Struct(Struct<'src>),
 	Instance(Option<&'src str>),
 
+	BrickColor,
 	Color3,
 	Vector3,
 	AlignedCFrame,
@@ -214,6 +215,7 @@ impl<'src> Ty<'src> {
 
 			Self::Instance(_) => (4, Some(4)),
 
+			Self::BrickColor => (2, Some(2)),
 			Self::Boolean => (1, Some(1)),
 			Self::Color3 => (12, Some(12)),
 			Self::Vector3 => (12, Some(12)),

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -264,7 +264,11 @@ impl Des {
 
 			Ty::BrickColor => self.push_assign(
 				into,
-				Expr::Call(Box::new(Var::from("BrickColor").nindex("new")), None, vec![self.readu16()]),
+				Expr::Call(
+					Box::new(Var::from("BrickColor").nindex("new")),
+					None,
+					vec![self.readu16()],
+				),
 			),
 
 			Ty::DateTimeMillis => self.push_assign(

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -262,6 +262,11 @@ impl Des {
 			// unknown is always an opt
 			Ty::Unknown => unreachable!(),
 
+			Ty::BrickColor => self.push_assign(
+				into,
+				Expr::Call(Box::new(Var::from("BrickColor").nindex("new")), None, vec![self.readu16()]),
+			),
+
 			Ty::Boolean => self.push_assign(into, self.readu8().eq(1.0.into())),
 			Ty::Color3 => self.push_assign(
 				into,

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -248,6 +248,12 @@ impl Ser {
 
 			Ty::BrickColor => self.push_writeu16(from.clone().nindex("Number").into()),
 
+			Ty::Vector3 => {
+				self.push_writef32(from.clone().nindex("X").into());
+				self.push_writef32(from.clone().nindex("Y").into());
+				self.push_writef32(from.clone().nindex("Z").into());
+			}
+
 			Ty::AlignedCFrame => {
 				self.push_local(
 					"axis_alignment",

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -246,11 +246,7 @@ impl Ser {
 				));
 			}
 
-			Ty::Vector3 => {
-				self.push_writef32(from.clone().nindex("X").into());
-				self.push_writef32(from.clone().nindex("Y").into());
-				self.push_writef32(from.clone().nindex("Z").into());
-			}
+			Ty::BrickColor => self.push_writeu16(from.clone().nindex("Number").into()),
 
 			Ty::AlignedCFrame => {
 				self.push_local(

--- a/zap/src/output/luau/mod.rs
+++ b/zap/src/output/luau/mod.rs
@@ -171,6 +171,7 @@ pub trait Output {
 
 			Ty::Instance(name) => self.push(name.unwrap_or("Instance")),
 
+			Ty::BrickColor => self.push("BrickColor"),
 			Ty::Unknown => self.push("unknown"),
 			Ty::Boolean => self.push("boolean"),
 			Ty::Color3 => self.push("Color3"),

--- a/zap/src/output/typescript/mod.rs
+++ b/zap/src/output/typescript/mod.rs
@@ -176,6 +176,7 @@ pub trait Output {
 
 			Ty::Instance(name) => self.push(name.unwrap_or("Instance")),
 
+			Ty::BrickColor => self.push("BrickColor"),
 			Ty::Unknown => self.push("unknown"),
 			Ty::Boolean => self.push("boolean"),
 			Ty::Color3 => self.push("Color3"),

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -414,6 +414,7 @@ impl<'src> Converter<'src> {
 				let name = ref_ty.name;
 
 				match name {
+					"BrickColor" => Ty::BrickColor,
 					"boolean" => Ty::Boolean,
 					"Color3" => Ty::Color3,
 					"Vector3" => Ty::Vector3,


### PR DESCRIPTION
Adds a BrickColor type to zap, as BrickColors can be serialized more efficiently than Color3s as they can be serialized as only a u16