### PR TITLE
Add Vector2 type

### DIFF
--- a/docs/config/types.md
+++ b/docs/config/types.md
@@ -215,11 +215,15 @@ local CFrameSpecialCases = {
 }
 ```
 
+## Vectors
+
+Zap supports serializing Vector3s, although zap has both a Vector3 type and a Vector2 type. Zap does not allow the use of Vector2s, and instead only allows Vector3s as Vector2s don't use luaus native vector type. And thus zaps Vector2 type is almost the same as the Vector3 type, except it doesn't serialize the Z axis.
+
 ## Other Roblox Classes
 
 The following Roblox Classes are also available as types in Zap:
 
-- `Vector3`
+- `Color3`
 
 ## Optional Types
 

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -127,6 +127,7 @@ pub enum Ty<'src> {
 	Struct(Struct<'src>),
 	Instance(Option<&'src str>),
 
+	Vector2,
 	Color3,
 	Vector3,
 	AlignedCFrame,
@@ -214,6 +215,7 @@ impl<'src> Ty<'src> {
 
 			Self::Instance(_) => (4, Some(4)),
 
+			Self::Vector2 => (8, Some(8)),
 			Self::Boolean => (1, Some(1)),
 			Self::Color3 => (12, Some(12)),
 			Self::Vector3 => (12, Some(12)),

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -306,8 +306,11 @@ impl Des {
 
 			Ty::Vector2 => self.push_assign(
 				into,
-				Expr::Call(Box::new(Var::from("Vector3").nindex("new")), None, 
-				vec![self.readf32(), self.readf32(), "0".into()]),
+				Expr::Call(
+					Box::new(Var::from("Vector3").nindex("new")),
+					None,
+					vec![self.readf32(), self.readf32(), "0".into()],
+				),
 			),
 
 			Ty::Vector3 => self.push_assign(into, self.readvector3()),

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -263,6 +263,7 @@ impl Des {
 			Ty::Unknown => unreachable!(),
 
 			Ty::Boolean => self.push_assign(into, self.readu8().eq(1.0.into())),
+
 			Ty::Color3 => self.push_assign(
 				into,
 				Expr::Color3(
@@ -271,7 +272,15 @@ impl Des {
 					Box::new(self.readu8()),
 				),
 			),
+
+			Ty::Vector2 => self.push_assign(
+				into,
+				Expr::Call(Box::new(Var::from("Vector3").nindex("new")), None, 
+				vec![self.readf32(), self.readf32(), "0".into()]),
+			),
+
 			Ty::Vector3 => self.push_assign(into, self.readvector3()),
+
 			Ty::AlignedCFrame => {
 				self.push_local("axis_alignment", Some(self.readu8()));
 

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -312,7 +312,6 @@ impl Des {
 					vec![self.readf32(), self.readf32(), "0".into()],
 				),
 			),
-
 			Ty::Vector3 => self.push_assign(into, self.readvector3()),
 
 			Ty::AlignedCFrame => {

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -246,6 +246,11 @@ impl Ser {
 				));
 			}
 
+			Ty::Vector2 => {
+				self.push_writef32(from.clone().nindex("X").into());
+				self.push_writef32(from.clone().nindex("Y").into());
+			}
+
 			Ty::Vector3 => {
 				self.push_writef32(from.clone().nindex("X").into());
 				self.push_writef32(from.clone().nindex("Y").into());

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -247,10 +247,10 @@ impl Ser {
 			}
 
 			Ty::BrickColor => self.push_writeu16(from.clone().nindex("Number").into()),
-			
+
 			Ty::DateTimeMillis => self.push_writef64(from.clone().nindex("UnixTimestampMillis").into()),
 			Ty::DateTime => self.push_writef64(from.clone().nindex("UnixTimestamp").into()),
-			
+
 			Ty::Vector2 => {
 				self.push_writef32(from.clone().nindex("X").into());
 				self.push_writef32(from.clone().nindex("Y").into());

--- a/zap/src/output/luau/mod.rs
+++ b/zap/src/output/luau/mod.rs
@@ -171,6 +171,7 @@ pub trait Output {
 
 			Ty::Instance(name) => self.push(name.unwrap_or("Instance")),
 
+			Ty::Vector2 => self.push("Vector3"),
 			Ty::Unknown => self.push("unknown"),
 			Ty::Boolean => self.push("boolean"),
 			Ty::Color3 => self.push("Color3"),

--- a/zap/src/output/typescript/mod.rs
+++ b/zap/src/output/typescript/mod.rs
@@ -179,6 +179,7 @@ pub trait Output {
 			Ty::Unknown => self.push("unknown"),
 			Ty::Boolean => self.push("boolean"),
 			Ty::Color3 => self.push("Color3"),
+			Ty::Vector2 => self.push("Vector3"),
 			Ty::Vector3 => self.push("Vector3"),
 			Ty::AlignedCFrame => self.push("CFrame"),
 			Ty::CFrame => self.push("CFrame"),

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -414,6 +414,7 @@ impl<'src> Converter<'src> {
 				let name = ref_ty.name;
 
 				match name {
+					"Vector2" => Ty::Vector2,
 					"boolean" => Ty::Boolean,
 					"Color3" => Ty::Color3,
 					"Vector3" => Ty::Vector3,


### PR DESCRIPTION
Closes https://github.com/red-blox/zap/issues/78, adds in a Vector2 type to zap, same as the Vector3 type except that it doesn't serialize the Z axis.