### PR TITLE
Use RunService.PostSimulation instead of RunService.Heartbeat

### DIFF
--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -133,7 +133,7 @@ impl<'src> ClientOutput<'src> {
 			self.push_line(&format!("local function {send_events}()"));
 			self.indent();
 		} else {
-			self.push_line("RunService.Heartbeat:Connect(function(dt)");
+			self.push_line("RunService.PostSimulation:Connect(function(dt)");
 			self.indent();
 			self.push_line("time += dt");
 			self.push("\n");

--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -140,7 +140,7 @@ impl<'a> ServerOutput<'a> {
 
 			self.push_line(&format!("local function {send_events}()"));
 		} else {
-			self.push_line("RunService.Heartbeat:Connect(function()");
+			self.push_line("RunService.PostSimulation:Connect(function()");
 		}
 
 		self.indent();


### PR DESCRIPTION
This change provides no benefit as both events are the same, except that the event loop wont show under Heartbeat with robloxs core scripts and instead under PostSimulation in the dev console ScriptProfiler. As its nice to be able to easily tell whats code you can touch within the profiler, and whats code you cant touch.