### PR TITLE
(typescript) Use  `Map<K, V>` to allow any key type 

### DIFF
--- a/zap/src/output/typescript/mod.rs
+++ b/zap/src/output/typescript/mod.rs
@@ -112,11 +112,11 @@ pub trait Output: ConfigProvider {
 			},
 
 			Ty::Map(key, val) => {
-				self.push("{ [index: ");
+				self.push("Map<");
 				self.push_ty(key);
-				self.push("]: ");
+				self.push(", ");
 				self.push_ty(val);
-				self.push(" }");
+				self.push(">");
 			}
 
 			Ty::Opt(ty) => {


### PR DESCRIPTION
Currently, the map type outputs `{ [index: K]: V }`, which only allows for `string | number | symbol` key types. Using the `Map<K, V>` type would allow for other key types to be used, like Instances.