### PR TITLE
Equalize `String` and `str` conversion to `Expr`

### DIFF
--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -411,8 +411,8 @@ impl Expr {
 }
 
 impl From<String> for Expr {
-	fn from(string: String) -> Self {
-		Self::Str(string)
+	fn from(name: String) -> Self {
+		Self::Var(Box::new(Var::Name(name)))
 	}
 }
 


### PR DESCRIPTION
Requires #113, which would have been prevented by this. `Expr::Str` can be used explicitly to output string literals.