### PR TITLE
Mention table keys in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Zap is a blazingly fast networking solution for Roblox.
 
 - Zap packs data into buffers with no overhead. The same data can be sent using a fraction of the bandwidth.
 - Zap doesn't compromise on performance. Zap's packing and unpacking is typically faster than Roblox's generic encoding.
-- Zap supports table keys `RemoteEvent`s don't, like tables, `Vector3`s, `Instance`s, or non-array integers.
+- Extended support of data types sendable through the network.
 - For both the IDL and API, Zap is a joy to use. It's easy to learn, easy to use, and easy to debug. It's the best DX you'll find.
 - Zap is fully secure. Buffers make reverse engineering your game's networking much harder and Zap validates all data received.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Zap is a blazingly fast networking solution for Roblox.
 
 - Zap packs data into buffers with no overhead. The same data can be sent using a fraction of the bandwidth.
 - Zap doesn't compromise on performance. Zap's packing and unpacking is typically faster than Roblox's generic encoding.
+- Zap supports table keys `RemoteEvent`s don't, like tables, `Vector3`s, `Instance`s, or non-array integers.
 - For both the IDL and API, Zap is a joy to use. It's easy to learn, easy to use, and easy to debug. It's the best DX you'll find.
 - Zap is fully secure. Buffers make reverse engineering your game's networking much harder and Zap validates all data received.
 

--- a/docs/intro/what-is-zap.md
+++ b/docs/intro/what-is-zap.md
@@ -32,9 +32,9 @@ Zap's IDL is easy to learn and easy to use. It's simple while still being expres
 
 Zap's API is fully typesafe, with Luau or TypeScript. You'll recieve full type checking and autocompletion in your editor.
 
-### Uncompromised Maps
+### Extended Type Support
 
-Map from anything to anything. If your keys' datatype is sendable through a `RemoteEvent` at all, Zap handles your table. 
+Zap supports far more types than normal `RemoteEvent` serialization does. Maps with numbers or `Instance`s as keys are good examples.
 
 ## 🔒 Security
 

--- a/docs/intro/what-is-zap.md
+++ b/docs/intro/what-is-zap.md
@@ -34,7 +34,7 @@ Zap's API is fully typesafe, with Luau or TypeScript. You'll recieve full type c
 
 ### Uncompromised Maps
 
-Map from anything to anything. If your keys' datatype is sendable through a `RemoteEvent` at all, Zap handles it. 
+Map from anything to anything. If your keys' datatype is sendable through a `RemoteEvent` at all, Zap handles your table. 
 
 ## 🔒 Security
 

--- a/docs/intro/what-is-zap.md
+++ b/docs/intro/what-is-zap.md
@@ -32,6 +32,10 @@ Zap's IDL is easy to learn and easy to use. It's simple while still being expres
 
 Zap's API is fully typesafe, with Luau or TypeScript. You'll recieve full type checking and autocompletion in your editor.
 
+### Uncompromised Maps
+
+Map from anything to anything. If your keys' datatype is sendable through a `RemoteEvent` at all, Zap handles it. 
+
 ## 🔒 Security
 
 Zap is fully secure. Buffers make reverse engineering your game's networking much harder and Zap validates all data received.


### PR DESCRIPTION
Why is this worth mentioning? Tables are everything to Luau, `RemoteEvent` serialization doesn't respect them, and Zap does.