### PR TITLE
Allow boolean literals in enums

### DIFF
--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -45,8 +45,7 @@ impl Des {
 					} else {
 						self.push_stmt(Stmt::ElseIf(enum_value_expr.clone().eq((i as f64).into())));
 					}
-
-					self.push_assign(into.clone(), Expr::Str(enumerator.to_string()));
+					self.push_assign(into.clone(), Expr::StrOrBool(enumerator.to_string()));
 				}
 
 				self.push_stmt(Stmt::Else);
@@ -67,7 +66,7 @@ impl Des {
 						self.push_stmt(Stmt::ElseIf(enum_value_expr.clone().eq((i as f64).into())));
 					}
 
-					self.push_assign(into.clone().nindex(*tag), Expr::Str(name.to_string()));
+					self.push_assign(into.clone().nindex(*tag), Expr::StrOrBool(name.to_string()));
 					self.push_struct(struct_ty, into.clone());
 				}
 

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -329,6 +329,7 @@ pub enum Expr {
 	Nil,
 
 	// Literals
+	StrOrBool(String),
 	Str(String),
 	Var(Box<Var>),
 	Num(f64),
@@ -441,6 +442,15 @@ impl Display for Expr {
 			Self::True => write!(f, "true"),
 			Self::Nil => write!(f, "nil"),
 
+			Self::StrOrBool(string) => {
+				if string == "false" || string == "False" {
+					return write!(f, "false")
+				} else if string == "true" || string == "True" {
+					return write!(f, "true")
+				} else {
+					return write!(f, "\"{}\"", string)
+				}
+			},
 			Self::Str(string) => write!(f, "\"{}\"", string),
 			Self::Var(var) => write!(f, "{}", var),
 			Self::Num(num) => write!(f, "{}", num),

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -445,7 +445,7 @@ impl Display for Expr {
 			Self::StrOrBool(string) => {
 				if string == "false" || string == "False" {
 					return write!(f, "false")
-				} else if string == "true" || string == "True" {
+				} else if string == "true" {
 					return write!(f, "true")
 				} else {
 					return write!(f, "\"{}\"", string)

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -445,7 +445,7 @@ impl Display for Expr {
 			Self::Str(string) => write!(f, "\"{}\"", string),
 			Self::StrOrBool(string) => {
 				if string == "false" {
-					write!(f, "\"{}\"", string)
+					write!(f, "false")
 				} else if string == "true" {
 					write!(f, "true")
 				} else {

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -442,16 +442,17 @@ impl Display for Expr {
 			Self::True => write!(f, "true"),
 			Self::Nil => write!(f, "nil"),
 
+			Self::Str(string) => write!(f, "\"{}\"", string),
 			Self::StrOrBool(string) => {
 				if string == "false" {
-					return write!(f, "false")
+					write!(f, "false")
 				} else if string == "true" {
-					return write!(f, "true")
+					write!(f, "true")
 				} else {
-					return write!(f, "\"{}\"", string)
+					write!(f, "\"{}\"", string)
 				}
-			},
-			Self::Str(string) => write!(f, "\"{}\"", string),
+			}
+
 			Self::Var(var) => write!(f, "{}", var),
 			Self::Num(num) => write!(f, "{}", num),
 

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -445,7 +445,7 @@ impl Display for Expr {
 			Self::Str(string) => write!(f, "\"{}\"", string),
 			Self::StrOrBool(string) => {
 				if string == "false" {
-					write!(f, "false")
+					write!(f, "\"{}\"", string)
 				} else if string == "true" {
 					write!(f, "true")
 				} else {

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -444,10 +444,8 @@ impl Display for Expr {
 
 			Self::Str(string) => write!(f, "\"{}\"", string),
 			Self::StrOrBool(string) => {
-				if string == "false" {
-					write!(f, "false")
-				} else if string == "true" {
-					write!(f, "true")
+				if string == "false" || string == "true" {
+					write!(f, "{}", string)
 				} else {
 					write!(f, "\"{}\"", string)
 				}

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -329,8 +329,8 @@ pub enum Expr {
 	Nil,
 
 	// Literals
-	StrOrBool(String),
 	Str(String),
+	StrOrBool(String),
 	Var(Box<Var>),
 	Num(f64),
 

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -443,7 +443,7 @@ impl Display for Expr {
 			Self::Nil => write!(f, "nil"),
 
 			Self::StrOrBool(string) => {
-				if string == "false" || string == "False" {
+				if string == "false" {
 					return write!(f, "false")
 				} else if string == "true" {
 					return write!(f, "true")

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -39,9 +39,9 @@ impl Ser {
 
 				for (i, enumerator) in enumerators.iter().enumerate() {
 					if i == 0 {
-						self.push_stmt(Stmt::If(from_expr.clone().eq(Expr::Str(enumerator.to_string()))));
+						self.push_stmt(Stmt::If(from_expr.clone().eq(Expr::StrOrBool(enumerator.to_string()))));
 					} else {
-						self.push_stmt(Stmt::ElseIf(from_expr.clone().eq(Expr::Str(enumerator.to_string()))));
+						self.push_stmt(Stmt::ElseIf(from_expr.clone().eq(Expr::StrOrBool(enumerator.to_string()))));
 					}
 
 					self.push_writenumty((i as f64).into(), numty);
@@ -57,9 +57,9 @@ impl Ser {
 
 				for (i, variant) in variants.iter().enumerate() {
 					if i == 0 {
-						self.push_stmt(Stmt::If(tag_expr.clone().eq(Expr::Str(variant.0.to_string()))));
+						self.push_stmt(Stmt::If(tag_expr.clone().eq(Expr::StrOrBool(variant.0.to_string()))));
 					} else {
-						self.push_stmt(Stmt::ElseIf(tag_expr.clone().eq(Expr::Str(variant.0.to_string()))));
+						self.push_stmt(Stmt::ElseIf(tag_expr.clone().eq(Expr::StrOrBool(variant.0.to_string()))));
 					}
 
 					self.push_writeu8((i as f64).into());

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -41,7 +41,9 @@ impl Ser {
 					if i == 0 {
 						self.push_stmt(Stmt::If(from_expr.clone().eq(Expr::StrOrBool(enumerator.to_string()))));
 					} else {
-						self.push_stmt(Stmt::ElseIf(from_expr.clone().eq(Expr::StrOrBool(enumerator.to_string()))));
+						self.push_stmt(Stmt::ElseIf(
+							from_expr.clone().eq(Expr::StrOrBool(enumerator.to_string())),
+						));
 					}
 
 					self.push_writenumty((i as f64).into(), numty);
@@ -59,7 +61,9 @@ impl Ser {
 					if i == 0 {
 						self.push_stmt(Stmt::If(tag_expr.clone().eq(Expr::StrOrBool(variant.0.to_string()))));
 					} else {
-						self.push_stmt(Stmt::ElseIf(tag_expr.clone().eq(Expr::StrOrBool(variant.0.to_string()))));
+						self.push_stmt(Stmt::ElseIf(
+							tag_expr.clone().eq(Expr::StrOrBool(variant.0.to_string())),
+						));
 					}
 
 					self.push_writeu8((i as f64).into());

--- a/zap/src/output/luau/mod.rs
+++ b/zap/src/output/luau/mod.rs
@@ -143,7 +143,11 @@ pub trait Output {
 
 						self.push_indent();
 
-						self.push(&format!("{tag}: \"{name}\",\n"));
+						if name.to_string() == "true" || name.to_string() == "false" {
+							self.push(&format!("{tag}: {name},\n"));
+						} else {
+							self.push(&format!("{tag}: \"{name}\",\n"));
+						}
 
 						for (name, ty) in struct_ty.fields.iter() {
 							self.push_indent();

--- a/zap/src/output/luau/mod.rs
+++ b/zap/src/output/luau/mod.rs
@@ -143,7 +143,7 @@ pub trait Output {
 
 						self.push_indent();
 
-						if name.to_string() == "true" || name.to_string() == "false" {
+						if *name == "true" || *name == "false" {
 							self.push(&format!("{tag}: {name},\n"));
 						} else {
 							self.push(&format!("{tag}: \"{name}\",\n"));

--- a/zap/src/output/typescript/mod.rs
+++ b/zap/src/output/typescript/mod.rs
@@ -156,7 +156,7 @@ pub trait Output: ConfigProvider {
 
 						self.push_indent();
 
-						if name.to_string() == "true" || name.to_string() == "false" {
+						if *name == "true" || *name == "false" {
 							self.push(&format!("{tag}: {name},\n"));
 						} else {
 							self.push(&format!("{tag}: \"{name}\",\n"));

--- a/zap/src/output/typescript/mod.rs
+++ b/zap/src/output/typescript/mod.rs
@@ -156,7 +156,11 @@ pub trait Output: ConfigProvider {
 
 						self.push_indent();
 
-						self.push(&format!("{tag}: \"{name}\",\n"));
+						if name.to_string() == "true" || name.to_string() == "false" {
+							self.push(&format!("{tag}: {name},\n"));
+						} else {
+							self.push(&format!("{tag}: \"{name}\",\n"));
+						}
 
 						for (name, ty) in struct_ty.fields.iter() {
 							self.push_indent();


### PR DESCRIPTION
This pr adds support for boolean literals in enums, a pattern that is useful for result types

ex:
```Luau
event EVENTI_RESULT = {
	from: Server,
	type: Reliable,
	call: ManyAsync,
	data: enum "succeeded" {
		true {
			from_action: enum { SCHEDULE, END, REMOVE, START, TELEPORT }
		},
		false {
			from_action: enum { SCHEDULE, END, REMOVE, START, TELEPORT },
			error: string,
		}
	},
}
```