### PR TITLE
Add function returns with `YieldType::Future` or `YieldType::Yield`

### DIFF
--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -732,12 +732,9 @@ impl<'src> ClientOutput<'src> {
 			self.push(")");
 
 			if let Some(ty) = &fndecl.rets {
-				match self.config.yield_type {
-					YieldType::Yield => {
-						self.push(": ");
-						self.push_ty(ty);
-					}
-					_ => (),
+				if self.config.yield_type == YieldType::Yield {
+					self.push(": ");
+					self.push_ty(ty);
 				}
 			}
 

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -729,7 +729,19 @@ impl<'src> ClientOutput<'src> {
 				self.push_ty(ty);
 			}
 
-			self.push(")\n");
+			self.push(")");
+
+			if let Some(ty) = &fndecl.rets {
+				match self.config.yield_type {
+					YieldType::Yield => {
+						self.push(": ");
+						self.push_ty(ty);
+					},
+					_ => (),
+				}
+			}
+
+			self.push("\n");
 			self.indent();
 
 			self.push_write_event_id(fndecl.id);

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -736,7 +736,7 @@ impl<'src> ClientOutput<'src> {
 					YieldType::Yield => {
 						self.push(": ");
 						self.push_ty(ty);
-					},
+					}
 					_ => (),
 				}
 			}

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -732,9 +732,17 @@ impl<'src> ClientOutput<'src> {
 			self.push(")");
 
 			if let Some(ty) = &fndecl.rets {
-				if self.config.yield_type == YieldType::Yield {
-					self.push(": ");
-					self.push_ty(ty);
+				match self.config.yield_type {
+					YieldType::Future => {
+						self.push(": Future.Future<");
+						self.push_ty(ty);
+						self.push(">");
+					},
+					YieldType::Yield => {
+						self.push(": ");
+						self.push_ty(ty);
+					},
+					_ => (),
 				}
 			}
 

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -737,11 +737,11 @@ impl<'src> ClientOutput<'src> {
 						self.push(": Future.Future<");
 						self.push_ty(ty);
 						self.push(">");
-					},
+					}
 					YieldType::Yield => {
 						self.push(": ");
 						self.push_ty(ty);
-					},
+					}
 					_ => (),
 				}
 			}


### PR DESCRIPTION
Another attempt of #124. Emit is now better when using `YieldType::Future` or `YieldType::Yield`, and no worse when not.

Assumes `Future` type exists in `async_lib` when `async_type = "future"`.

There's no type when using `Promise`s without TypeScript, this can probably change once the new solver releases, but it would be breaking.