### PR TITLE
Remove returning `table.freeze`

### DIFF
--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -559,13 +559,13 @@ impl<'src> ClientOutput<'src> {
 			.iter()
 			.filter(|ev_decl| ev_decl.from == EvSource::Client)
 		{
-			self.push_line(&format!("{name} = table.freeze({{", name = ev.name));
+			self.push_line(&format!("{name} = {{", name = ev.name));
 			self.indent();
 
 			self.push_return_fire(ev);
 
 			self.dedent();
-			self.push_line("}),");
+			self.push_line("},");
 		}
 	}
 
@@ -698,7 +698,7 @@ impl<'src> ClientOutput<'src> {
 			.iter()
 			.filter(|ev_decl| ev_decl.from == EvSource::Server)
 		{
-			self.push_line(&format!("{name} = table.freeze({{", name = ev.name));
+			self.push_line(&format!("{name} = {{", name = ev.name));
 			self.indent();
 
 			match ev.call {
@@ -707,7 +707,7 @@ impl<'src> ClientOutput<'src> {
 			}
 
 			self.dedent();
-			self.push_line("}),");
+			self.push_line("},");
 		}
 	}
 
@@ -718,7 +718,7 @@ impl<'src> ClientOutput<'src> {
 		for fndecl in self.config.fndecls.iter() {
 			let id = fndecl.id;
 
-			self.push_line(&format!("{name} = table.freeze({{", name = fndecl.name));
+			self.push_line(&format!("{name} = {{", name = fndecl.name));
 			self.indent();
 
 			self.push_indent();
@@ -729,24 +729,7 @@ impl<'src> ClientOutput<'src> {
 				self.push_ty(ty);
 			}
 
-			self.push(")");
-
-			if let Some(ty) = &fndecl.rets {
-				match self.config.yield_type {
-					YieldType::Future => {
-						self.push(": Future.Future<");
-						self.push_ty(ty);
-						self.push(">");
-					}
-					YieldType::Yield => {
-						self.push(": ");
-						self.push_ty(ty);
-					}
-					_ => (),
-				}
-			}
-
-			self.push("\n");
+			self.push(")\n");
 			self.indent();
 
 			self.push_write_event_id(fndecl.id);
@@ -803,12 +786,12 @@ impl<'src> ClientOutput<'src> {
 			self.push_line("end,");
 
 			self.dedent();
-			self.push_line("}),");
+			self.push_line("},");
 		}
 	}
 
 	pub fn push_return(&mut self) {
-		self.push_line("local returns = table.freeze({");
+		self.push_line("local returns = {");
 		self.indent();
 
 		let send_events = self.config.casing.with("SendEvents", "sendEvents", "send_events");
@@ -820,7 +803,7 @@ impl<'src> ClientOutput<'src> {
 		self.push_return_functions();
 
 		self.dedent();
-		self.push_line("})");
+		self.push_line("}");
 
 		self.push_line("type Events = typeof(returns)");
 		self.push_line("return returns");

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -729,7 +729,7 @@ impl<'src> ClientOutput<'src> {
 				self.push_ty(ty);
 			}
 
-			self.push(")\n");
+			self.push(")");
 
 			if let Some(ty) = &fndecl.rets {
 				match self.config.yield_type {

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -730,6 +730,23 @@ impl<'src> ClientOutput<'src> {
 			}
 
 			self.push(")\n");
+
+			if let Some(ty) = &fndecl.rets {
+				match self.config.yield_type {
+					YieldType::Future => {
+						self.push(": Future.Future<");
+						self.push_ty(ty);
+						self.push(">");
+					}
+					YieldType::Yield => {
+						self.push(": ");
+						self.push_ty(ty);
+					}
+					_ => (),
+				}
+			}
+
+			self.push("\n");
 			self.indent();
 
 			self.push_write_event_id(fndecl.id);

--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -703,7 +703,7 @@ impl<'a> ServerOutput<'a> {
 			.iter()
 			.filter(|ev_decl| ev_decl.from == EvSource::Server)
 		{
-			self.push_line(&format!("{name} = table.freeze({{", name = ev.name));
+			self.push_line(&format!("{name} = {{", name = ev.name));
 			self.indent();
 
 			self.push_return_fire(ev);
@@ -713,7 +713,7 @@ impl<'a> ServerOutput<'a> {
 			self.push_return_fire_set(ev);
 
 			self.dedent();
-			self.push_line("}),");
+			self.push_line("},");
 		}
 	}
 
@@ -825,7 +825,7 @@ impl<'a> ServerOutput<'a> {
 			.iter()
 			.filter(|ev_decl| ev_decl.from == EvSource::Client)
 		{
-			self.push_line(&format!("{} = table.freeze({{", ev.name));
+			self.push_line(&format!("{} = {{", ev.name));
 			self.indent();
 
 			match ev.call {
@@ -834,22 +834,22 @@ impl<'a> ServerOutput<'a> {
 			}
 
 			self.dedent();
-			self.push_line("}),");
+			self.push_line("},");
 		}
 
 		for fndecl in self.config.fndecls.iter() {
-			self.push_line(&format!("{} = table.freeze({{", fndecl.name));
+			self.push_line(&format!("{} = {{", fndecl.name));
 			self.indent();
 
 			self.push_fn_return(fndecl);
 
 			self.dedent();
-			self.push_line("}),");
+			self.push_line("},");
 		}
 	}
 
 	pub fn push_return(&mut self) {
-		self.push_line("local returns = table.freeze({");
+		self.push_line("local returns = {");
 		self.indent();
 
 		let send_events = self.config.casing.with("SendEvents", "sendEvents", "send_events");
@@ -860,7 +860,7 @@ impl<'a> ServerOutput<'a> {
 		self.push_return_listen();
 
 		self.dedent();
-		self.push_line("})");
+		self.push_line("}");
 
 		self.push_line("type Events = typeof(returns)");
 		self.push_line("return returns");


### PR DESCRIPTION
`table.freeze` inconsistently causes firing events with Zap not to typecheck at all in the old solver. From testing it's when `table.freeze` is combined with `--!nocheck` or `--!nonstrict` and called into from a `--!strict` module.

`table.freeze` is bugged in the new solver, and even if that were fixed the new solver isn't yet quite ready for general use.

It should be added back later, which would be easy.