### PR TITLE
(typescript) Add ` | undefined` to emit for optional

### DIFF
--- a/zap/src/output/typescript/mod.rs
+++ b/zap/src/output/typescript/mod.rs
@@ -216,6 +216,7 @@ pub trait Output: ConfigProvider {
 			} else {
 				self.push("?: ");
 				self.push_ty(ty);
+				self.push(" | undefined");
 			}
 		} else {
 			self.push(": ");


### PR DESCRIPTION
This makes optional properties emit as `{ property?: type | undefined }` which fixes issues when `exactOptionalPropertyTypes` is set to true in tsconfig, such as when trying to fire an event with a possibly undefined value.