### PR TITLE
Prevent remote function errors with actors

### DIFF
--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -325,7 +325,7 @@ impl<'src> ClientOutput<'src> {
 			YieldType::Yield | YieldType::Future => {
 				self.push_line(&format!("local thread = event_queue[{id}][call_id]"));
 				self.push_line("-- When using actors it's possible for multiple Zap clients to exist, but only one called the Zap remote function.");
-				self.push_line(&format!("if thread then"));
+				self.push_line("if thread then");
 				self.indent();
 				self.push_line(&format!("task.spawn(thread, {values})"));
 				self.dedent();

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -321,20 +321,20 @@ impl<'src> ClientOutput<'src> {
 			self.push_stmts(&des::gen(data, &get_unnamed_values("value", data.len()), true));
 		}
 
+		self.push_line(&format!("local thread = event_queue[{id}][call_id]"));
+		self.push_line("-- When using actors it's possible for multiple Zap clients to exist, but only one called the Zap remote function.");
+		self.push_line("if thread then");
+		self.indent();
 		match self.config.yield_type {
 			YieldType::Yield | YieldType::Future => {
-				self.push_line(&format!("local thread = event_queue[{id}][call_id]"));
-				self.push_line("-- When using actors it's possible for multiple Zap clients to exist, but only one called the Zap remote function.");
-				self.push_line("if thread then");
-				self.indent();
 				self.push_line(&format!("task.spawn(thread, {values})"));
-				self.dedent();
-				self.push_line("end");
 			}
 			YieldType::Promise => {
-				self.push_line(&format!("event_queue[{id}][call_id]({values})"));
+				self.push_line(&format!("thread({values})"));
 			}
 		}
+		self.dedent();
+		self.push_line("end");
 
 		self.push_line(&format!("event_queue[{id}][call_id] = nil"));
 

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -323,7 +323,13 @@ impl<'src> ClientOutput<'src> {
 
 		match self.config.yield_type {
 			YieldType::Yield | YieldType::Future => {
-				self.push_line(&format!("task.spawn(event_queue[{id}][call_id], {values})"));
+				self.push_line(&format!("local thread = event_queue[{id}][call_id]"));
+				self.push_line("-- When using actors it's possible for multiple Zap clients to exist, but only one called the Zap remote function.");
+				self.push_line(&format!("if thread then"));
+				self.indent();
+				self.push_line(&format!("task.spawn(thread, {values})"));
+				self.dedent();
+				self.push_line("end");
 			}
 			YieldType::Promise => {
 				self.push_line(&format!("event_queue[{id}][call_id]({values})"));


### PR DESCRIPTION
Since there can be multiple Zap instances when using actors, there can be multiple `RemoteEvent.OnClientEvent` listeners. Only the listener from the VM that fired the remote function will have a valid thread to resume execution at. This change simply ignores the remote function return on any other VM.

Reported by Phoenix in ROSS.
