### PR TITLE
Fix remote function multiple returns

### DIFF
--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -340,7 +340,9 @@ impl<'a> ServerOutput<'a> {
 			self.dedent();
 			self.push_line(&format!("end, player, call_id, {values})"));
 		} else {
-			self.push_line(&format!("local {rets_string} = reliable_events[{server_id}](player, {values})"));
+			self.push_line(&format!(
+				"local {rets_string} = reliable_events[{server_id}](player, {values})"
+			));
 
 			self.push_line("load_player(player)");
 			self.push_write_event_id(fndecl.client_id, self.config.client_reliable_ty());

--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -320,7 +320,9 @@ impl<'a> ServerOutput<'a> {
 			self.push_line(&format!("task.spawn(function(player_2, call_id_2, {args})"));
 			self.indent();
 
-			self.push_line(&format!("local {rets_string} = reliable_events[{server_id}](player_2, {args})"));
+			self.push_line(&format!(
+				"local {rets_string} = reliable_events[{server_id}](player_2, {args})"
+			));
 
 			self.push_line("load_player(player_2)");
 			self.push_write_event_id(fndecl.client_id, self.config.client_reliable_ty());

--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -340,7 +340,7 @@ impl<'a> ServerOutput<'a> {
 			self.dedent();
 			self.push_line(&format!("end, player, call_id, {values})"));
 		} else {
-			self.push_line(&format!("local {rets_string} = events[{server_id}](player, {values})"));
+			self.push_line(&format!("local {rets_string} = reliable_events[{server_id}](player, {values})"));
 
 			self.push_line("load_player(player)");
 			self.push_write_event_id(fndecl.client_id, self.config.client_reliable_ty());

--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -296,11 +296,7 @@ impl<'a> ServerOutput<'a> {
 
 		self.indent();
 
-		let rets = if let Some(types) = &fndecl.rets {
-			types
-		} else {
-			&vec![]
-		};
+		let rets = if let Some(types) = &fndecl.rets { types } else { &vec![] };
 
 		let rets_string = if !rets.is_empty() {
 			(1..=rets.len())

--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -296,7 +296,12 @@ impl<'a> ServerOutput<'a> {
 
 		self.indent();
 
-		let rets = fndecl.rets.clone().unwrap_or(vec![]);
+		let rets = if let Some(types) = &fndecl.rets {
+			types
+		} else {
+			&vec![]
+		};
+
 		let rets_string = if !rets.is_empty() {
 			(1..=rets.len())
 				.map(|i| format!("ret_{}", i))


### PR DESCRIPTION
Reported by J-ian in ROSS.

This also fixes a separate issue with #143 on latest where this code still refers to `events` instead of `reliable_events`.

I stopped calling `get_unnamed_values` because there are other callsites I didn't want to mess with.