### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - '0.6.x'
     paths: 
       - '**.rs'
-      - Cargo.{lock,toml}
+      - 'Cargo.{lock,toml}'
 
   pull_request:
     branches:
@@ -17,7 +17,7 @@ on:
       - '0.6.x'
     paths: 
       - '**.rs'
-      - Cargo.{lock,toml}
+      - 'Cargo.{lock,toml}'
 
 jobs:
   build:
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,4 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Clippy
-        run: cargo clippy
+        run: cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,13 +24,13 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: yarn
       - name: Get latest zap release
-        uses: robinraju/release-downloader@v1.8
+        uses: robinraju/release-downloader@v1
         with:
           latest: true
           fileName: "zap-*-wasm.tgz"
@@ -41,10 +41,9 @@ jobs:
         run: yarn install --frozen-lockfile --force
       - name: Build
         run: yarn docs:build
-      - uses: actions/configure-pages@v2
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/.vitepress/dist
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,11 @@ jobs:
     steps:
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
           draft: true
-          prerelease: false
 
   build:
     needs: ["create-release"]
@@ -59,7 +56,7 @@ jobs:
     env:
       BIN: zap
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get Version from Tag
         shell: bash
@@ -99,7 +96,7 @@ jobs:
           fi
 
       - name: Upload Archive to Release
-        uses: actions/upload-release-asset@v1
+        uses: shogo82148/actions-upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -109,7 +106,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Upload Archive to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.BIN }}-${{ env.PROJECT_VERSION }}-${{ matrix.label }}.zip
           path: release.zip
@@ -121,7 +118,7 @@ jobs:
     env:
       BIN: zap
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get Version from Tag
         shell: bash
@@ -131,7 +128,7 @@ jobs:
           echo "Version is: ${{ env.PROJECT_VERSION }}"
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -152,7 +149,7 @@ jobs:
           wasm-pack pack zap
 
       - name: Upload Archive to Release
-        uses: actions/upload-release-asset@v1
+        uses: shogo82148/actions-upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -162,7 +159,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Upload Archive to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.BIN }}-${{ env.PROJECT_VERSION }}-wasm.tgz
           path: zap/pkg/${{ env.BIN }}-${{ env.PROJECT_VERSION }}.tgz


### PR DESCRIPTION
Some of the GitHub Actions we use will be depricated on the 30th of January, so we need to replace them.
Unfortunately, `actions/create-release` and `actions/upload-release-asset` are no longer maintained by GitHub so we had to switch to community ones.