### PR TITLE
Disallow f64 vector components

### DIFF
--- a/docs/config/types.md
+++ b/docs/config/types.md
@@ -229,10 +229,10 @@ local CFrameSpecialCases = {
 
 ## Vectors
 
-Zap supports `vector`s with any numeric component types. The Z component is optional, and will result in a `0` if omitted.
+Zap supports `vector`s with any numeric components other than `F64`. The Z component is optional, and will result in a `0` if omitted.
 
-<CodeBlock code="type Position = vector(f64, f64, f64)" />
-<CodeBlock code="type Size = vector(u8, f64)" />
+<CodeBlock code="type Position = vector(f32, f32, f32)" />
+<CodeBlock code="type Size = vector(u8, f32)" />
 
 Omitting all components will emit `vector(f32, f32, f32)`.
 <CodeBlock code="type Position = vector" />

--- a/docs/config/types.md
+++ b/docs/config/types.md
@@ -229,7 +229,7 @@ local CFrameSpecialCases = {
 
 ## Vectors `[0.6.17+]`
 
-Zap supports `vector`s with any numeric components other than `F64`. The Z component is optional, and will result in a `0` if omitted.
+Zap supports `vector`s with any numeric components other than `f64`. The Z component is optional, and will result in a `0` if omitted.
 
 <CodeBlock code="type Position = vector(f32, f32, f32)" />
 <CodeBlock code="type Size = vector(u8, f32)" />

--- a/docs/config/types.md
+++ b/docs/config/types.md
@@ -227,7 +227,7 @@ local CFrameSpecialCases = {
 }
 ```
 
-## Vectors
+## Vectors `[0.6.17+]`
 
 Zap supports `vector`s with any numeric components other than `F64`. The Z component is optional, and will result in a `0` if omitted.
 

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -501,7 +501,7 @@ impl<'src> Converter<'src> {
 				match self.ty(x_ty) {
 					Ty::Num(numty, _) => {
 						if let NumTy::F64 = numty {
-							self.report(Report::AnalyzeInvalidVectorType {
+							self.report(Report::AnalyzeOversizeVectorComponent {
 								span: Span {
 									start: x_ty.start,
 									end: x_ty.end,
@@ -509,7 +509,7 @@ impl<'src> Converter<'src> {
 							});
 						}
 					}
-					_ => self.report(Report::AnalyzeInvalidVectorType {
+					_ => self.report(Report::AnalyzeOversizeVectorComponent {
 						span: Span {
 							start: x_ty.start,
 							end: x_ty.end,
@@ -519,7 +519,7 @@ impl<'src> Converter<'src> {
 				match self.ty(y_ty) {
 					Ty::Num(numty, _) => {
 						if let NumTy::F64 = numty {
-							self.report(Report::AnalyzeInvalidVectorType {
+							self.report(Report::AnalyzeOversizeVectorComponent {
 								span: Span {
 									start: y_ty.start,
 									end: y_ty.end,

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::config::{
-	Casing, Config, Enum, EvDecl, EvSource, EvType, FnDecl, Parameter, Range, Struct, Ty, TyDecl, YieldType,
+	Casing, Config, Enum, EvDecl, EvSource, EvType, FnDecl, NumTy, Parameter, Range, Struct, Ty, TyDecl, YieldType,
 };
 
 use super::{
@@ -499,7 +499,16 @@ impl<'src> Converter<'src> {
 
 			SyntaxTyKind::Vector(x_ty, y_ty, z_ty) => {
 				match self.ty(x_ty) {
-					Ty::Num(_, _) => (),
+					Ty::Num(numty, _) => {
+						if let NumTy::F64 = numty {
+							self.report(Report::AnalyzeInvalidVectorType {
+								span: Span {
+									start: x_ty.start,
+									end: x_ty.end,
+								},
+							});
+						}
+					}
 					_ => self.report(Report::AnalyzeInvalidVectorType {
 						span: Span {
 							start: x_ty.start,
@@ -508,7 +517,16 @@ impl<'src> Converter<'src> {
 					}),
 				};
 				match self.ty(y_ty) {
-					Ty::Num(_, _) => (),
+					Ty::Num(numty, _) => {
+						if let NumTy::F64 = numty {
+							self.report(Report::AnalyzeInvalidVectorType {
+								span: Span {
+									start: y_ty.start,
+									end: y_ty.end,
+								},
+							})
+						}
+					}
 					_ => self.report(Report::AnalyzeInvalidVectorType {
 						span: Span {
 							start: y_ty.start,
@@ -518,7 +536,16 @@ impl<'src> Converter<'src> {
 				};
 				if let Some(z_ty) = z_ty {
 					match self.ty(z_ty) {
-						Ty::Num(_, _) => (),
+						Ty::Num(numty, _) => {
+							if let NumTy::F64 = numty {
+								self.report(Report::AnalyzeInvalidVectorType {
+									span: Span {
+										start: z_ty.start,
+										end: z_ty.end,
+									},
+								})
+							}
+						}
 						_ => self.report(Report::AnalyzeInvalidVectorType {
 							span: Span {
 								start: z_ty.start,

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -538,7 +538,7 @@ impl<'src> Converter<'src> {
 					match self.ty(z_ty) {
 						Ty::Num(numty, _) => {
 							if let NumTy::F64 = numty {
-								self.report(Report::AnalyzeInvalidVectorType {
+								self.report(Report::AnalyzeOversizeVectorComponent {
 									span: Span {
 										start: z_ty.start,
 										end: z_ty.end,

--- a/zap/src/parser/reports.rs
+++ b/zap/src/parser/reports.rs
@@ -53,6 +53,10 @@ pub enum Report<'src> {
 		span: Span,
 	},
 
+	AnalyzeOversizeVectorComponent {
+		span: Span,
+	},
+
 	AnalyzeEmptyEnum {
 		span: Span,
 	},
@@ -131,6 +135,7 @@ impl Report<'_> {
 			Self::AnalyzePotentiallyOversizeUnreliable { .. } => Severity::Warning,
 			Self::AnalyzeInvalidRange { .. } => Severity::Error,
 			Self::AnalyzeInvalidVectorType { .. } => Severity::Error,
+			Self::AnalyzeOversizeVectorComponent { .. } => Severity::Error,
 			Self::AnalyzeEmptyEnum { .. } => Severity::Error,
 			Self::AnalyzeEnumTagUsed { .. } => Severity::Error,
 			Self::AnalyzeInvalidOptValue { .. } => Severity::Error,
@@ -163,6 +168,7 @@ impl Report<'_> {
 			Self::AnalyzePotentiallyOversizeUnreliable { .. } => "potentially oversize unreliable".to_string(),
 			Self::AnalyzeInvalidRange { .. } => "invalid range".to_string(),
 			Self::AnalyzeInvalidVectorType { .. } => "invalid vector type".to_string(),
+			Self::AnalyzeOversizeVectorComponent { .. } => "vectors cannot represent F64s".to_string(),
 			Self::AnalyzeEmptyEnum { .. } => "empty enum".to_string(),
 			Self::AnalyzeEnumTagUsed { .. } => "enum tag used in variant".to_string(),
 			Self::AnalyzeInvalidOptValue { expected, .. } => format!("invalid opt value, expected {}", expected),
@@ -204,6 +210,7 @@ impl Report<'_> {
 			Self::AnalyzeDuplicateParameter { .. } => "3015",
 			Self::AnalyzeNamedReturn { .. } => "3016",
 			Self::AnalyzeInvalidVectorType { .. } => "3017",
+			Self::AnalyzeOversizeVectorComponent { .. } => "3018",
 		}
 	}
 
@@ -249,6 +256,10 @@ impl Report<'_> {
 
 			Self::AnalyzeInvalidVectorType { span } => {
 				vec![Label::primary((), span.clone()).with_message("invalid vector component type")]
+			}
+
+			Self::AnalyzeOversizeVectorComponent { span } => {
+				vec![Label::primary((), span.clone()).with_message("oversized vector component type")]
 			}
 
 			Self::AnalyzeEmptyEnum { span } => {
@@ -349,6 +360,9 @@ impl Report<'_> {
 			]),
 			Self::AnalyzeInvalidVectorType { .. } => {
 				Some(vec!["only numeric types are valid vector components".to_string()])
+			}
+			Self::AnalyzeOversizeVectorComponent { .. } => {
+				Some(vec!["F64 is not a valid vector component".to_string()])
 			}
 			Self::AnalyzeEmptyEnum { .. } => Some(vec![
 				"enums cannot be empty".to_string(),

--- a/zap/src/parser/reports.rs
+++ b/zap/src/parser/reports.rs
@@ -168,7 +168,7 @@ impl Report<'_> {
 			Self::AnalyzePotentiallyOversizeUnreliable { .. } => "potentially oversize unreliable".to_string(),
 			Self::AnalyzeInvalidRange { .. } => "invalid range".to_string(),
 			Self::AnalyzeInvalidVectorType { .. } => "invalid vector type".to_string(),
-			Self::AnalyzeOversizeVectorComponent { .. } => "vectors cannot represent F64s".to_string(),
+			Self::AnalyzeOversizeVectorComponent { .. } => "vectors cannot represent f64s".to_string(),
 			Self::AnalyzeEmptyEnum { .. } => "empty enum".to_string(),
 			Self::AnalyzeEnumTagUsed { .. } => "enum tag used in variant".to_string(),
 			Self::AnalyzeInvalidOptValue { expected, .. } => format!("invalid opt value, expected {}", expected),
@@ -362,7 +362,7 @@ impl Report<'_> {
 				Some(vec!["only numeric types are valid vector components".to_string()])
 			}
 			Self::AnalyzeOversizeVectorComponent { .. } => {
-				Some(vec!["F64 is not a valid vector component".to_string()])
+				Some(vec!["f64 is not a valid vector component".to_string()])
 			}
 			Self::AnalyzeEmptyEnum { .. } => Some(vec![
 				"enums cannot be empty".to_string(),


### PR DESCRIPTION
This also adds a version requirement note to the heading of the vector docs. I think this should be replaced by a small box next to the heading.