### PR TITLE
Optimize length storage

### DIFF
--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -428,7 +428,7 @@ impl Range {
 	}
 
 	pub fn numty(&self) -> Option<NumTy> {
-		Some(NumTy::from_f64(self.min.unwrap_or_default(), self.max?))
+		Some(NumTy::from_f64(self.min.unwrap_or(0.0), self.max?))
 	}
 }
 

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -426,6 +426,14 @@ impl Range {
 			None
 		}
 	}
+
+	pub fn numty(&self) -> Option<NumTy> {
+		let (Some(min), Some(max)) = (self.min, self.max) else {
+			return None;
+		};
+
+		Some(NumTy::from_f64(min, max))
+	}
 }
 
 impl Display for Range {

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -428,11 +428,7 @@ impl Range {
 	}
 
 	pub fn numty(&self) -> Option<NumTy> {
-		let (Some(min), Some(max)) = (self.min, self.max) else {
-			return None;
-		};
-
-		Some(NumTy::from_f64(min, max))
+		Some(NumTy::from_f64(self.min.unwrap_or_default(), self.max?))
 	}
 }
 

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -101,7 +101,10 @@ impl Des<'_> {
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
 
-					self.push_local(len_name.clone(), Some(self.readnumty(NumTy::U16)));
+					self.push_local(
+						len_name.clone(),
+						Some(self.readnumty(range.numty().unwrap_or(NumTy::U16))),
+					);
 
 					if self.checks {
 						self.push_range_check(len_expr.clone(), *range);
@@ -116,7 +119,10 @@ impl Des<'_> {
 					self.push_read_copy(into, len.into());
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					self.push_local(len_name.clone(), Some(self.readnumty(NumTy::U16)));
+					self.push_local(
+						len_name.clone(),
+						Some(self.readnumty(range.numty().unwrap_or(NumTy::U16))),
+					);
 
 					if self.checks {
 						self.push_range_check(len_expr.clone(), *range);
@@ -143,7 +149,10 @@ impl Des<'_> {
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
 
-					self.push_local(len_name.clone(), Some(self.readnumty(NumTy::U16)));
+					self.push_local(
+						len_name.clone(),
+						Some(self.readnumty(range.numty().unwrap_or(NumTy::U16))),
+					);
 
 					if self.checks {
 						self.push_range_check(len_expr.clone(), *range);

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -110,7 +110,7 @@ impl Ser<'_> {
 						self.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_writeu16(len_expr.clone());
+					self.push_writenumty(len_expr.clone(), range.numty().unwrap_or(NumTy::U16));
 					self.push_writestring(from_expr, len_expr.clone());
 				}
 			}
@@ -133,7 +133,7 @@ impl Ser<'_> {
 						self.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_writeu16(len_expr.clone());
+					self.push_writenumty(len_expr.clone(), range.numty().unwrap_or(NumTy::U16));
 					self.push_write_copy(from_expr, len_name.as_str().into())
 				}
 			}
@@ -162,7 +162,7 @@ impl Ser<'_> {
 						self.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_writeu16(len_expr.clone());
+					self.push_writenumty(len_expr.clone(), range.numty().unwrap_or(NumTy::U16));
 
 					self.push_stmt(Stmt::NumFor {
 						var: var_name.clone(),


### PR DESCRIPTION
Storing lengths was hardcoded to u16, even when a different type would be better. So, now if the range of length is known it'll be used to serialize the length in the fitting size.

This currently requires explicit minimum values (`0..255`). Should a minimum of 0 be default?