### PR TITLE
Fix tooling deserializer for unreliable events

### DIFF
--- a/zap/src/output/tooling.rs
+++ b/zap/src/output/tooling.rs
@@ -462,11 +462,6 @@ impl<'src> ToolingOutput<'src> {
 
 		self.push_unreliable_events();
 
-		self.push_line("else");
-		self.indent();
-		self.push_line("error(`Unknown remote instance: {remote_instance}`)");
-		self.dedent();
-
 		self.push_line("end");
 
 		self.dedent();

--- a/zap/src/output/tooling.rs
+++ b/zap/src/output/tooling.rs
@@ -462,6 +462,11 @@ impl<'src> ToolingOutput<'src> {
 
 		self.push_unreliable_events();
 
+		self.push_line("else");
+		self.indent();
+		self.push_line("error(`Unknown remote instance: {remote_instance}`)");
+		self.dedent();
+
 		self.push_line("end");
 
 		self.dedent();
@@ -549,7 +554,7 @@ impl<'src> ToolingOutput<'src> {
 			self.push_indent();
 			self.push("elseif ");
 
-			if ev_decl.from == EvSource::Client {
+			if ev_decl.from == EvSource::Server {
 				self.push("not ");
 			}
 


### PR DESCRIPTION
The check for whether the event is received on the client or server was opposite of what it should be.

I also added an error message if the user passes a non-zap remote instance to the tooling deserializer.