### PR TITLE
Support quoted identifiers with spaces

### DIFF
--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -33,7 +33,7 @@ impl Gen for Des<'_> {
 impl Des<'_> {
 	fn push_struct(&mut self, struct_ty: &Struct, into: Var) {
 		for (name, ty) in struct_ty.fields.iter() {
-			self.push_ty(ty, into.clone().nindex(*name))
+			self.push_ty(ty, into.clone().eindex(Expr::Str((*name).into())))
 		}
 	}
 
@@ -72,7 +72,10 @@ impl Des<'_> {
 						self.push_stmt(Stmt::ElseIf(enum_value_expr.clone().eq((i as f64).into())));
 					}
 
-					self.push_assign(into.clone().nindex(*tag), Expr::StrOrBool(name.to_string()));
+					self.push_assign(
+						into.clone().eindex(Expr::Str((*tag).into())),
+						Expr::StrOrBool(name.to_string()),
+					);
 					self.push_struct(struct_ty, into.clone());
 				}
 

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -33,7 +33,7 @@ impl Gen for Ser<'_> {
 impl Ser<'_> {
 	fn push_struct(&mut self, struct_ty: &Struct, from: Var) {
 		for (name, ty) in struct_ty.fields.iter() {
-			self.push_ty(ty, from.clone().nindex(*name));
+			self.push_ty(ty, from.clone().eindex(Expr::Str((*name).into())));
 		}
 	}
 
@@ -61,7 +61,7 @@ impl Ser<'_> {
 			}
 
 			Enum::Tagged { tag, variants } => {
-				let tag_expr = Expr::from(from.clone().nindex(*tag));
+				let tag_expr = Expr::from(from.clone().eindex(Expr::Str((*tag).into())));
 
 				for (i, variant) in variants.iter().enumerate() {
 					if i == 0 {

--- a/zap/src/output/luau/mod.rs
+++ b/zap/src/output/luau/mod.rs
@@ -147,14 +147,14 @@ pub trait Output {
 						self.push_indent();
 
 						if *name == "true" || *name == "false" {
-							self.push(&format!("{tag}: {name},\n"));
+							self.push(&format!("[\"{tag}\"]: {name},\n"));
 						} else {
-							self.push(&format!("{tag}: \"{name}\",\n"));
+							self.push(&format!("[\"{tag}\"]: \"{name}\",\n"));
 						}
 
 						for (name, ty) in struct_ty.fields.iter() {
 							self.push_indent();
-							self.push(&format!("{name}: "));
+							self.push(&format!("[\"{name}\"]: "));
 							self.push_ty(ty);
 							self.push(",\n");
 						}
@@ -173,7 +173,7 @@ pub trait Output {
 
 				for (name, ty) in struct_ty.fields.iter() {
 					self.push_indent();
-					self.push(&format!("{name}: "));
+					self.push(&format!("[\"{name}\"]: "));
 					self.push_ty(ty);
 					self.push(",\n");
 				}

--- a/zap/src/output/typescript/mod.rs
+++ b/zap/src/output/typescript/mod.rs
@@ -158,14 +158,16 @@ pub trait Output: ConfigProvider {
 						self.push_indent();
 
 						if *name == "true" || *name == "false" {
-							self.push(&format!("{tag}: {name},\n"));
+							self.push(&format!("[\"{tag}\"]: {name},\n"));
 						} else {
-							self.push(&format!("{tag}: \"{name}\",\n"));
+							self.push(&format!("[\"{tag}\"]: \"{name}\",\n"));
 						}
 
 						for (name, ty) in struct_ty.fields.iter() {
 							self.push_indent();
+							self.push("[\"");
 							self.push(name);
+							self.push("\"]");
 							self.push_arg_ty(ty);
 							self.push(",\n");
 						}
@@ -184,7 +186,9 @@ pub trait Output: ConfigProvider {
 
 				for (name, ty) in struct_ty.fields.iter() {
 					self.push_indent();
+					self.push("[\"");
 					self.push(name);
+					self.push("\"]");
 					self.push_arg_ty(ty);
 					self.push(",\n");
 				}

--- a/zap/src/parser/grammar.lalrpop
+++ b/zap/src/parser/grammar.lalrpop
@@ -145,13 +145,13 @@ Enum: SyntaxEnum<'input> = {
 }
 
 EnumKind: SyntaxEnumKind<'input> = {
-    "{" <enumerators:Comma<Identifier>> "}" => SyntaxEnumKind::Unit(enumerators),
+    "{" <enumerators:Comma<KeyIdentifier>> "}" => SyntaxEnumKind::Unit(enumerators),
 
-    <tag:StrLit> "{" <variants:Comma<(<Identifier> <Struct>)>> "}" => SyntaxEnumKind::Tagged { tag, variants },
+    <tag:StrLit> "{" <variants:Comma<(<KeyIdentifier> <Struct>)>> "}" => SyntaxEnumKind::Tagged { tag, variants },
 }
 
 Struct: SyntaxStruct<'input> = {
-    <start:@L> "{" <fields:Comma<(<Identifier> ":" <Ty>)>> "}" <end:@R> => SyntaxStruct { start, fields, end },
+    <start:@L> "{" <fields:Comma<(<KeyIdentifier> ":" <Ty>)>> "}" <end:@R> => SyntaxStruct { start, fields, end },
 }
 
 IntRange: SyntaxRange<'input> = {
@@ -228,6 +228,11 @@ Identifier: SyntaxIdentifier<'input> = {
     <start:@L> "set" <end:@R> => SyntaxIdentifier { start, name: "set", end },
     <start:@L> "true" <end:@R> => SyntaxIdentifier { start, name: "true", end },
     <start:@L> "false" <end:@R> => SyntaxIdentifier { start, name: "false", end },
+}
+
+KeyIdentifier: SyntaxIdentifier<'input> = {
+    Identifier,
+    <start:@L> <s:StrLit> <end:@R> => SyntaxIdentifier { start, name: &s.value[1..s.value.len() - 1], end },
 }
 
 Comma<T>: Vec<T> = {

--- a/zap/tests/files/struct_quoted_fields.zap
+++ b/zap/tests/files/struct_quoted_fields.zap
@@ -1,0 +1,9 @@
+event MyEvent = {
+    from: Server,
+    type: Reliable,
+    call: ManyAsync,
+    data: struct {
+        "foo bar": string,
+        buzz: u8
+    }
+}

--- a/zap/tests/files/tagged_enum_quoted.zap
+++ b/zap/tests/files/tagged_enum_quoted.zap
@@ -1,0 +1,9 @@
+event MyEvent = {
+    from: Server,
+    type: Reliable,
+    call: ManyAsync,
+    data: enum "tag with spaces" {
+        foo { "value with spaces": string, bar: u8 },
+        bar { buzz: u8 },
+    }
+}

--- a/zap/tests/files/unit_enum_quoted.zap
+++ b/zap/tests/files/unit_enum_quoted.zap
@@ -1,0 +1,6 @@
+event MyEvent = {
+    from: Server,
+    type: Reliable,
+    call: ManyAsync,
+    data: enum { "Foo Bar", "Bar Foo", Buzz }
+}

--- a/zap/tests/irgen/mod.rs
+++ b/zap/tests/irgen/mod.rs
@@ -299,3 +299,58 @@ async fn test_no_data() {
 
 	runtime.run("Zap", output).await.unwrap();
 }
+
+#[tokio::test]
+async fn test_unit_enum_quoted() {
+	let (config, reports) = parse(include_str!("../files/unit_enum_quoted.zap"));
+
+	assert!(config.is_some());
+	assert!(reports.is_empty());
+
+	let default_value = r#""Foo Bar""#;
+
+	let default_values: HashMap<&str, Vec<&str>> = HashMap::from([("MyEvent", vec![default_value])]);
+	let output = TestOutput::new(&config.unwrap(), default_values).output();
+	let mut runtime = Runtime::new();
+
+	runtime.run("Zap", output).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_struct_quoted_fields() {
+	let (config, reports) = parse(include_str!("../files/struct_quoted_fields.zap"));
+
+	assert!(config.is_some());
+	assert!(reports.is_empty());
+
+	let default_value = r#"{
+		["foo bar"] = "baz",
+		buzz = 21
+	}"#;
+
+	let default_values: HashMap<&str, Vec<&str>> = HashMap::from([("MyEvent", vec![default_value])]);
+	let output = TestOutput::new(&config.unwrap(), default_values).output();
+	let mut runtime = Runtime::new();
+
+	runtime.run("Zap", output).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_tagged_enum_quoted() {
+	let (config, reports) = parse(include_str!("../files/tagged_enum_quoted.zap"));
+
+	assert!(config.is_some());
+	assert!(reports.is_empty());
+
+	let default_value = r#"{
+		["tag with spaces"] = "foo",
+		["value with spaces"] = "buzz",
+		bar = 21
+	}"#;
+
+	let default_values: HashMap<&str, Vec<&str>> = HashMap::from([("MyEvent", vec![default_value])]);
+	let output = TestOutput::new(&config.unwrap(), default_values).output();
+	let mut runtime = Runtime::new();
+
+	runtime.run("Zap", output).await.unwrap();
+}

--- a/zap/tests/lune/snapshots/run_lune_test@struct_quoted_fields.snap
+++ b/zap/tests/lune/snapshots/run_lune_test@struct_quoted_fields.snap
@@ -1,0 +1,8 @@
+---
+source: zap/tests/lune/mod.rs
+expression: result
+input_file: zap/tests/files/struct_quoted_fields.zap
+---
+Ok(
+    0,
+)

--- a/zap/tests/lune/snapshots/run_lune_test@tagged_enum_quoted.snap
+++ b/zap/tests/lune/snapshots/run_lune_test@tagged_enum_quoted.snap
@@ -1,0 +1,8 @@
+---
+source: zap/tests/lune/mod.rs
+expression: result
+input_file: zap/tests/files/tagged_enum_quoted.zap
+---
+Ok(
+    0,
+)

--- a/zap/tests/lune/snapshots/run_lune_test@unit_enum_quoted.snap
+++ b/zap/tests/lune/snapshots/run_lune_test@unit_enum_quoted.snap
@@ -1,0 +1,8 @@
+---
+source: zap/tests/lune/mod.rs
+expression: result
+input_file: zap/tests/files/unit_enum_quoted.zap
+---
+Ok(
+    0,
+)

--- a/zap/tests/selene/snapshots/run_selene_test@struct_quoted_fields@client.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@struct_quoted_fields@client.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: client_diagnostics
+input_file: zap/tests/files/struct_quoted_fields.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@struct_quoted_fields@server.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@struct_quoted_fields@server.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: server_diagnostics
+input_file: zap/tests/files/struct_quoted_fields.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@struct_quoted_fields@tooling.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@struct_quoted_fields@tooling.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: tooling_diagnostics
+input_file: zap/tests/files/struct_quoted_fields.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@struct_quoted_fields@types.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@struct_quoted_fields@types.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: types_diagnostics
+input_file: zap/tests/files/struct_quoted_fields.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@tagged_enum_quoted@client.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@tagged_enum_quoted@client.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: client_diagnostics
+input_file: zap/tests/files/tagged_enum_quoted.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@tagged_enum_quoted@server.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@tagged_enum_quoted@server.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: server_diagnostics
+input_file: zap/tests/files/tagged_enum_quoted.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@tagged_enum_quoted@tooling.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@tagged_enum_quoted@tooling.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: tooling_diagnostics
+input_file: zap/tests/files/tagged_enum_quoted.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@tagged_enum_quoted@types.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@tagged_enum_quoted@types.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: types_diagnostics
+input_file: zap/tests/files/tagged_enum_quoted.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@unit_enum_quoted@client.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@unit_enum_quoted@client.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: client_diagnostics
+input_file: zap/tests/files/unit_enum_quoted.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@unit_enum_quoted@server.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@unit_enum_quoted@server.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: server_diagnostics
+input_file: zap/tests/files/unit_enum_quoted.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@unit_enum_quoted@tooling.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@unit_enum_quoted@tooling.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: tooling_diagnostics
+input_file: zap/tests/files/unit_enum_quoted.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@unit_enum_quoted@types.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@unit_enum_quoted@types.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: types_diagnostics
+input_file: zap/tests/files/unit_enum_quoted.zap
+---
+[]


### PR DESCRIPTION
Adds support to quoting identifiers which are:
- keys of structs
- keys of tagged enums
- values of unit enums

Quoted identifiers are useful because they're allowed to contain spaces.

Additionally, fixes the types for tags of enums containing spaces.