### PR TITLE
Fix TypeScript types being emitted without typescript option

### DIFF
--- a/zap/src/output/typescript/types.rs
+++ b/zap/src/output/typescript/types.rs
@@ -72,5 +72,9 @@ impl<'a> TypesOutput<'a> {
 }
 
 pub fn code(config: &Config) -> Option<String> {
+	if !config.typescript {
+		return None;
+	}
+
 	Some(TypesOutput::new(config).output())
 }


### PR DESCRIPTION
The `types_output` option always emitted TypeScript definitions, even if the `typescript` option was disabled.