### PR TITLE
Fix buffer length check with `write_checks` on

### DIFF
--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -119,7 +119,13 @@ impl Ser<'_> {
 			Ty::Buf(range) => {
 				if let Some(len) = range.exact() {
 					if self.checks {
-						self.push_assert(from_expr.clone().len().eq(len.into()), None);
+						self.push_assert(
+							Var::from("buffer")
+								.nindex("len")
+								.call(vec![from_expr.clone()])
+								.eq(len.into()),
+							None,
+						);
 					}
 
 					self.push_write_copy(from_expr, len.into());


### PR DESCRIPTION
![](https://github.com/user-attachments/assets/649acb5c-1f92-49cb-9e69-3e5581b69afe)
```
event CustomTransform = {
  from: Client,
  type: Unreliable,
  call: ManyAsync,
  data: struct {
    Transform: buffer(19)
  }
}
```