### PR TITLE
Add offsets to NumTy algorithm

### DIFF
--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -217,7 +217,7 @@ impl<'src> Ty<'src> {
 				if let Some(exact) = len.exact() {
 					(exact as usize, Some(exact as usize))
 				} else {
-					let len_numty = len.numty().map(|numty| numty.numty).unwrap_or(NumTy::U16);
+					let len_numty = len.numty().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
 					(
 						len.min().map(|_| len_numty.min() as usize).unwrap_or(0) + len_numty.size(),
@@ -230,7 +230,7 @@ impl<'src> Ty<'src> {
 				if let Some(exact) = len.exact() {
 					(exact as usize, Some(exact as usize))
 				} else {
-					let len_numty = len.numty().map(|numty| numty.numty).unwrap_or(NumTy::U16);
+					let len_numty = len.numty().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
 					(
 						len.min().map(|_| len_numty.min() as usize).unwrap_or(0) + len_numty.size(),
@@ -241,7 +241,7 @@ impl<'src> Ty<'src> {
 
 			Self::Arr(ty, len) => {
 				let (ty_min, ty_max) = ty.size(tydecls, recursed);
-				let len_numty = len.numty().map(|numty| numty.numty).unwrap_or(NumTy::U16);
+				let len_numty = len.numty().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
 				if let Some(exact) = len.exact() {
 					(ty_min * (exact as usize), ty_max.map(|max| ty_max.unwrap() * max))
@@ -431,8 +431,17 @@ impl Range {
 		}
 	}
 
-	pub fn numty(&self) -> Option<OffsetNumTy> {
-		Some(OffsetNumTy::from_f64(self.min.unwrap_or(0.0), self.max?))
+	pub fn numty(&self) -> Option<(NumTy, f64)> {
+		let min = self.min.unwrap_or(0.0);
+		let max = self.max?;
+
+		let (min, max, offset) = if min > 0.0 {
+			(0.0, max - min, min)
+		} else {
+			(min, max, 0.0)
+		};
+
+		Some((NumTy::from_f64(min, max), offset))
 	}
 }
 
@@ -543,36 +552,6 @@ impl Display for NumTy {
 			NumTy::I8 => write!(f, "i8"),
 			NumTy::I16 => write!(f, "i16"),
 			NumTy::I32 => write!(f, "i32"),
-		}
-	}
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct OffsetNumTy {
-	pub numty: NumTy,
-	pub offset: f64,
-}
-
-impl Default for OffsetNumTy {
-	fn default() -> Self {
-		OffsetNumTy {
-			numty: NumTy::U16,
-			offset: 0.0,
-		}
-	}
-}
-
-impl OffsetNumTy {
-	pub fn from_f64(min: f64, max: f64) -> OffsetNumTy {
-		let (min, max, offset) = if min > 0.0 {
-			(0.0, max - min, min)
-		} else {
-			(min, max, 0.0)
-		};
-
-		OffsetNumTy {
-			numty: NumTy::from_f64(min, max),
-			offset,
 		}
 	}
 }

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -69,11 +69,11 @@ impl Config<'_> {
 	}
 
 	pub fn server_reliable_ty(&self) -> NumTy {
-		NumTy::from_f64_max(self.server_reliable_count() as f64 - 1.0)
+		NumTy::from_f64(0.0, self.server_reliable_count() as f64 - 1.0)
 	}
 
 	pub fn client_reliable_ty(&self) -> NumTy {
-		NumTy::from_f64_max(self.client_reliable_count() as f64 - 1.0)
+		NumTy::from_f64(0.0, self.client_reliable_count() as f64 - 1.0)
 	}
 }
 
@@ -217,7 +217,7 @@ impl<'src> Ty<'src> {
 				if let Some(exact) = len.exact() {
 					(exact as usize, Some(exact as usize))
 				} else {
-					let len_numty = len.numty().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
+					let len_numty = len.numty().map(|numty| numty.numty).unwrap_or(NumTy::U16);
 
 					(
 						len.min().map(|_| len_numty.min() as usize).unwrap_or(0) + len_numty.size(),
@@ -230,7 +230,7 @@ impl<'src> Ty<'src> {
 				if let Some(exact) = len.exact() {
 					(exact as usize, Some(exact as usize))
 				} else {
-					let len_numty = len.numty().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
+					let len_numty = len.numty().map(|numty| numty.numty).unwrap_or(NumTy::U16);
 
 					(
 						len.min().map(|_| len_numty.min() as usize).unwrap_or(0) + len_numty.size(),
@@ -241,7 +241,7 @@ impl<'src> Ty<'src> {
 
 			Self::Arr(ty, len) => {
 				let (ty_min, ty_max) = ty.size(tydecls, recursed);
-				let len_numty = len.numty().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
+				let len_numty = len.numty().map(|numty| numty.numty).unwrap_or(NumTy::U16);
 
 				if let Some(exact) = len.exact() {
 					(ty_min * (exact as usize), ty_max.map(|max| ty_max.unwrap() * max))
@@ -337,7 +337,7 @@ impl<'src> Enum<'src> {
 	) -> (usize, Option<usize>) {
 		match self {
 			Self::Unit(enumerators) => {
-				let numty = NumTy::from_f64_max(enumerators.len() as f64 - 1.0);
+				let numty = NumTy::from_f64(0.0, enumerators.len() as f64 - 1.0);
 
 				(numty.size(), Some(numty.size()))
 			}
@@ -431,8 +431,8 @@ impl Range {
 		}
 	}
 
-	pub fn numty(&self) -> Option<(NumTy, f64)> {
-		Some(NumTy::from_f64(self.min.unwrap_or(0.0), self.max?))
+	pub fn numty(&self) -> Option<OffsetNumTy> {
+		Some(OffsetNumTy::from_f64(self.min.unwrap_or(0.0), self.max?))
 	}
 }
 
@@ -462,14 +462,8 @@ pub enum NumTy {
 }
 
 impl NumTy {
-	pub fn from_f64(min: f64, max: f64) -> (NumTy, f64) {
-		let (min, max, offset) = if min > 0.0 {
-			(0.0, max - min, min)
-		} else {
-			(min, max, 0.0)
-		};
-
-		let numty = if min < 0.0 {
+	pub fn from_f64(min: f64, max: f64) -> NumTy {
+		if min < 0.0 {
 			if max < 0.0 {
 				NumTy::I32
 			} else if max <= u8::MAX as f64 {
@@ -487,13 +481,7 @@ impl NumTy {
 			NumTy::U32
 		} else {
 			NumTy::F64
-		};
-
-		(numty, offset)
-	}
-
-	pub fn from_f64_max(max: f64) -> NumTy {
-		NumTy::from_f64(0.0, max).0
+		}
 	}
 
 	pub fn size(&self) -> usize {
@@ -555,6 +543,36 @@ impl Display for NumTy {
 			NumTy::I8 => write!(f, "i8"),
 			NumTy::I16 => write!(f, "i16"),
 			NumTy::I32 => write!(f, "i32"),
+		}
+	}
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct OffsetNumTy {
+	pub numty: NumTy,
+	pub offset: f64,
+}
+
+impl Default for OffsetNumTy {
+	fn default() -> Self {
+		OffsetNumTy {
+			numty: NumTy::U16,
+			offset: 0.0,
+		}
+	}
+}
+
+impl OffsetNumTy {
+	pub fn from_f64(min: f64, max: f64) -> OffsetNumTy {
+		let (min, max, offset) = if min > 0.0 {
+			(0.0, max - min, min)
+		} else {
+			(min, max, 0.0)
+		};
+
+		OffsetNumTy {
+			numty: NumTy::from_f64(min, max),
+			offset,
 		}
 	}
 }

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -220,8 +220,8 @@ impl<'src> Ty<'src> {
 					let len_numty = len.numty().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
 					(
-						len.min().map(|_| len_numty.min() as usize).unwrap_or(0) + len_numty.size(),
-						len.max().map(|_| (len_numty.max() as usize) + len_numty.size()),
+						len.min().map(|min| min as usize).unwrap_or(0) + len_numty.size(),
+						len.max().map(|max| max as usize + len_numty.size()),
 					)
 				}
 			}
@@ -233,24 +233,25 @@ impl<'src> Ty<'src> {
 					let len_numty = len.numty().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
 					(
-						len.min().map(|_| len_numty.min() as usize).unwrap_or(0) + len_numty.size(),
-						len.max().map(|_| (len_numty.max() as usize) + len_numty.size()),
+						len.min().map(|min| min as usize).unwrap_or(0) + len_numty.size(),
+						len.max().map(|max| max as usize + len_numty.size()),
 					)
 				}
 			}
 
 			Self::Arr(ty, len) => {
 				let (ty_min, ty_max) = ty.size(tydecls, recursed);
+				let len_min = len.min().map(|min| min as usize).unwrap_or(0);
 				let len_numty = len.numty().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
 				if let Some(exact) = len.exact() {
 					(ty_min * (exact as usize), ty_max.map(|max| ty_max.unwrap() * max))
 				} else {
 					(
-						ty_min * (len_numty.min() as usize) + len_numty.size(),
+						ty_min * len_min + len_numty.size(),
 						ty_max
-							.filter(|_| len.max().is_some())
-							.map(|ty_max| ty_max * (len_numty.max() as usize) + len_numty.size()),
+							.and_then(|ty_max| len.max().map(|max| (ty_max, max as usize)))
+							.map(|(ty_max, max)| ty_max * max + len_numty.size()),
 					)
 				}
 			}

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -69,11 +69,11 @@ impl Config<'_> {
 	}
 
 	pub fn server_reliable_ty(&self) -> NumTy {
-		NumTy::from_f64(0.0, self.server_reliable_count() as f64 - 1.0)
+		NumTy::from_f64_max(self.server_reliable_count() as f64 - 1.0)
 	}
 
 	pub fn client_reliable_ty(&self) -> NumTy {
-		NumTy::from_f64(0.0, self.client_reliable_count() as f64 - 1.0)
+		NumTy::from_f64_max(self.client_reliable_count() as f64 - 1.0)
 	}
 }
 
@@ -217,11 +217,11 @@ impl<'src> Ty<'src> {
 				if let Some(exact) = len.exact() {
 					(exact as usize, Some(exact as usize))
 				} else {
-					let len_size = len.numty().unwrap_or(NumTy::U16).size();
+					let len_numty = len.numty().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
 					(
-						len.min().map(|min| min as usize).unwrap_or(0) + len_size,
-						len.max().map(|max| (max as usize) + len_size),
+						len.min().map(|_| len_numty.min() as usize).unwrap_or(0) + len_numty.size(),
+						len.max().map(|_| (len_numty.max() as usize) + len_numty.size()),
 					)
 				}
 			}
@@ -230,29 +230,28 @@ impl<'src> Ty<'src> {
 				if let Some(exact) = len.exact() {
 					(exact as usize, Some(exact as usize))
 				} else {
-					let len_size = len.numty().unwrap_or(NumTy::U16).size();
+					let len_numty = len.numty().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
 					(
-						len.min().map(|min| min as usize).unwrap_or(0) + len_size,
-						len.max().map(|max| (max as usize) + len_size),
+						len.min().map(|_| len_numty.min() as usize).unwrap_or(0) + len_numty.size(),
+						len.max().map(|_| (len_numty.max() as usize) + len_numty.size()),
 					)
 				}
 			}
 
 			Self::Arr(ty, len) => {
 				let (ty_min, ty_max) = ty.size(tydecls, recursed);
-				let len_min = len.min().map(|min| min as usize).unwrap_or(0);
-				let len_size = len.numty().unwrap_or(NumTy::U16).size();
+				let len_numty = len.numty().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
 				if let Some(exact) = len.exact() {
 					(ty_min * (exact as usize), ty_max.map(|max| ty_max.unwrap() * max))
-				} else if let Some(len_max) = len.max() {
-					(
-						ty_min * len_min + len_size,
-						ty_max.map(|ty_max| ty_max * (len_max as usize) + len_size),
-					)
 				} else {
-					(ty_min * len_min + len_size, None)
+					(
+						ty_min * (len_numty.min() as usize) + len_numty.size(),
+						ty_max
+							.filter(|_| len.max().is_some())
+							.map(|ty_max| ty_max * (len_numty.max() as usize) + len_numty.size()),
+					)
 				}
 			}
 
@@ -338,7 +337,7 @@ impl<'src> Enum<'src> {
 	) -> (usize, Option<usize>) {
 		match self {
 			Self::Unit(enumerators) => {
-				let numty = NumTy::from_f64(0.0, enumerators.len() as f64 - 1.0);
+				let numty = NumTy::from_f64_max(enumerators.len() as f64 - 1.0);
 
 				(numty.size(), Some(numty.size()))
 			}
@@ -432,7 +431,7 @@ impl Range {
 		}
 	}
 
-	pub fn numty(&self) -> Option<NumTy> {
+	pub fn numty(&self) -> Option<(NumTy, f64)> {
 		Some(NumTy::from_f64(self.min.unwrap_or(0.0), self.max?))
 	}
 }
@@ -463,8 +462,14 @@ pub enum NumTy {
 }
 
 impl NumTy {
-	pub fn from_f64(min: f64, max: f64) -> NumTy {
-		if min < 0.0 {
+	pub fn from_f64(min: f64, max: f64) -> (NumTy, f64) {
+		let (min, max, offset) = if min > 0.0 {
+			(0.0, max - min, min)
+		} else {
+			(min, max, 0.0)
+		};
+
+		let numty = if min < 0.0 {
 			if max < 0.0 {
 				NumTy::I32
 			} else if max <= u8::MAX as f64 {
@@ -482,7 +487,13 @@ impl NumTy {
 			NumTy::U32
 		} else {
 			NumTy::F64
-		}
+		};
+
+		(numty, offset)
+	}
+
+	pub fn from_f64_max(max: f64) -> NumTy {
+		NumTy::from_f64(0.0, max).0
 	}
 
 	pub fn size(&self) -> usize {

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -245,7 +245,7 @@ impl<'src> Ty<'src> {
 				let (len_numty, ..) = len.numty();
 
 				if let Some(exact) = len.exact() {
-					(ty_min * (exact as usize), ty_max.map(|max| ty_max.unwrap() * max))
+					(ty_min * (exact as usize), ty_max.map(|max| max * exact as usize))
 				} else {
 					(
 						ty_min * len_min + len_numty.size(),

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -250,8 +250,8 @@ impl<'src> Ty<'src> {
 					(
 						ty_min * len_min + len_numty.size(),
 						ty_max
-							.and_then(|ty_max| len.max().map(|max| (ty_max, max as usize)))
-							.map(|(ty_max, max)| ty_max * max + len_numty.size()),
+							.zip(len.max())
+							.map(|(ty_max, max)| ty_max * max as usize + len_numty.size()),
 					)
 				}
 			}

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -217,7 +217,7 @@ impl<'src> Ty<'src> {
 				if let Some(exact) = len.exact() {
 					(exact as usize, Some(exact as usize))
 				} else {
-					let len_numty = len.numty().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
+					let (len_numty, ..) = len.numty();
 
 					(
 						len.min().map(|min| min as usize).unwrap_or(0) + len_numty.size(),
@@ -230,7 +230,7 @@ impl<'src> Ty<'src> {
 				if let Some(exact) = len.exact() {
 					(exact as usize, Some(exact as usize))
 				} else {
-					let len_numty = len.numty().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
+					let (len_numty, ..) = len.numty();
 
 					(
 						len.min().map(|min| min as usize).unwrap_or(0) + len_numty.size(),
@@ -242,7 +242,7 @@ impl<'src> Ty<'src> {
 			Self::Arr(ty, len) => {
 				let (ty_min, ty_max) = ty.size(tydecls, recursed);
 				let len_min = len.min().map(|min| min as usize).unwrap_or(0);
-				let len_numty = len.numty().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
+				let (len_numty, ..) = len.numty();
 
 				if let Some(exact) = len.exact() {
 					(ty_min * (exact as usize), ty_max.map(|max| ty_max.unwrap() * max))
@@ -432,9 +432,9 @@ impl Range {
 		}
 	}
 
-	pub fn numty(&self) -> Option<(NumTy, f64)> {
+	pub fn numty(&self) -> (NumTy, f64) {
 		let min = self.min.unwrap_or(0.0);
-		let max = self.max?;
+		let Some(max) = self.max else { return (NumTy::U16, 0.0) };
 
 		let (min, max, offset) = if min > 0.0 {
 			(0.0, max - min, min)
@@ -442,7 +442,7 @@ impl Range {
 			(min, max, 0.0)
 		};
 
-		Some((NumTy::from_f64(min, max), offset))
+		(NumTy::from_f64(min, max), offset)
 	}
 }
 

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -40,7 +40,7 @@ impl Des<'_> {
 	fn push_enum(&mut self, enum_ty: &Enum, into: Var) {
 		match enum_ty {
 			Enum::Unit(enumerators) => {
-				let numty = NumTy::from_f64(0.0, enumerators.len() as f64 - 1.0);
+				let numty = NumTy::from_f64_max(enumerators.len() as f64 - 1.0);
 
 				let (enum_value_name, enum_value_expr) = self.add_occurrence("enum_value");
 				self.push_local(enum_value_name, Some(self.readnumty(numty)));
@@ -60,7 +60,7 @@ impl Des<'_> {
 			}
 
 			Enum::Tagged { tag, variants } => {
-				let numty = NumTy::from_f64(0.0, variants.len() as f64 - 1.0);
+				let numty = NumTy::from_f64_max(variants.len() as f64 - 1.0);
 
 				let (enum_value_name, enum_value_expr) = self.add_occurrence("enum_value");
 				self.push_local(enum_value_name, Some(self.readnumty(numty)));
@@ -103,10 +103,11 @@ impl Des<'_> {
 					self.push_assign(into, self.readstring(len.into()));
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
+					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
 
 					self.push_local(
 						len_name.clone(),
-						Some(self.readnumty(range.numty().unwrap_or(NumTy::U16))),
+						Some(self.readnumty(len_numty).add(Expr::Num(len_offset))),
 					);
 
 					if self.checks {
@@ -122,9 +123,11 @@ impl Des<'_> {
 					self.push_read_copy(into, len.into());
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
+					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
+
 					self.push_local(
 						len_name.clone(),
-						Some(self.readnumty(range.numty().unwrap_or(NumTy::U16))),
+						Some(self.readnumty(len_numty).add(Expr::Num(len_offset))),
 					);
 
 					if self.checks {
@@ -151,10 +154,11 @@ impl Des<'_> {
 					self.push_stmt(Stmt::End);
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
+					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
 
 					self.push_local(
 						len_name.clone(),
-						Some(self.readnumty(range.numty().unwrap_or(NumTy::U16))),
+						Some(self.readnumty(len_numty).add(Expr::Num(len_offset))),
 					);
 
 					if self.checks {

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -103,7 +103,7 @@ impl Des<'_> {
 					self.push_assign(into, self.readstring(len.into()));
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
+					let (len_numty, len_offset) = range.numty();
 
 					let mut offset_len_expr = self.readnumty(len_numty);
 					if len_offset != 0.0 {
@@ -125,7 +125,7 @@ impl Des<'_> {
 					self.push_read_copy(into, len.into());
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
+					let (len_numty, len_offset) = range.numty();
 
 					let mut offset_len_expr = self.readnumty(len_numty);
 					if len_offset != 0.0 {
@@ -158,7 +158,7 @@ impl Des<'_> {
 					self.push_stmt(Stmt::End);
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
+					let (len_numty, len_offset) = range.numty();
 
 					let mut offset_len_expr = self.readnumty(len_numty);
 					if len_offset != 0.0 {

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -40,7 +40,7 @@ impl Des<'_> {
 	fn push_enum(&mut self, enum_ty: &Enum, into: Var) {
 		match enum_ty {
 			Enum::Unit(enumerators) => {
-				let numty = NumTy::from_f64_max(enumerators.len() as f64 - 1.0);
+				let numty = NumTy::from_f64(0.0, enumerators.len() as f64 - 1.0);
 
 				let (enum_value_name, enum_value_expr) = self.add_occurrence("enum_value");
 				self.push_local(enum_value_name, Some(self.readnumty(numty)));
@@ -60,7 +60,7 @@ impl Des<'_> {
 			}
 
 			Enum::Tagged { tag, variants } => {
-				let numty = NumTy::from_f64_max(variants.len() as f64 - 1.0);
+				let numty = NumTy::from_f64(0.0, variants.len() as f64 - 1.0);
 
 				let (enum_value_name, enum_value_expr) = self.add_occurrence("enum_value");
 				self.push_local(enum_value_name, Some(self.readnumty(numty)));
@@ -103,11 +103,11 @@ impl Des<'_> {
 					self.push_assign(into, self.readstring(len.into()));
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
+					let len_numty = range.numty().unwrap_or_default();
 
 					self.push_local(
 						len_name.clone(),
-						Some(self.readnumty(len_numty).add(Expr::Num(len_offset))),
+						Some(self.readnumty(len_numty.numty).add(Expr::Num(len_numty.offset))),
 					);
 
 					if self.checks {
@@ -123,11 +123,11 @@ impl Des<'_> {
 					self.push_read_copy(into, len.into());
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
+					let len_numty = range.numty().unwrap_or_default();
 
 					self.push_local(
 						len_name.clone(),
-						Some(self.readnumty(len_numty).add(Expr::Num(len_offset))),
+						Some(self.readnumty(len_numty.numty).add(Expr::Num(len_numty.offset))),
 					);
 
 					if self.checks {
@@ -154,11 +154,11 @@ impl Des<'_> {
 					self.push_stmt(Stmt::End);
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
+					let len_numty = range.numty().unwrap_or_default();
 
 					self.push_local(
 						len_name.clone(),
-						Some(self.readnumty(len_numty).add(Expr::Num(len_offset))),
+						Some(self.readnumty(len_numty.numty).add(Expr::Num(len_numty.offset))),
 					);
 
 					if self.checks {

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -105,10 +105,12 @@ impl Des<'_> {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
 
-					self.push_local(
-						len_name.clone(),
-						Some(self.readnumty(len_numty).add(Expr::Num(len_offset))),
-					);
+					let mut offset_len_expr = self.readnumty(len_numty);
+					if len_offset != 0.0 {
+						offset_len_expr = offset_len_expr.add(Expr::Num(len_offset))
+					}
+
+					self.push_local(len_name.clone(), Some(offset_len_expr));
 
 					if self.checks {
 						self.push_range_check(len_expr.clone(), *range);
@@ -125,10 +127,12 @@ impl Des<'_> {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
 
-					self.push_local(
-						len_name.clone(),
-						Some(self.readnumty(len_numty).add(Expr::Num(len_offset))),
-					);
+					let mut offset_len_expr = self.readnumty(len_numty);
+					if len_offset != 0.0 {
+						offset_len_expr = offset_len_expr.add(Expr::Num(len_offset))
+					}
+
+					self.push_local(len_name.clone(), Some(offset_len_expr));
 
 					if self.checks {
 						self.push_range_check(len_expr.clone(), *range);
@@ -156,10 +160,12 @@ impl Des<'_> {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
 
-					self.push_local(
-						len_name.clone(),
-						Some(self.readnumty(len_numty).add(Expr::Num(len_offset))),
-					);
+					let mut offset_len_expr = self.readnumty(len_numty);
+					if len_offset != 0.0 {
+						offset_len_expr = offset_len_expr.add(Expr::Num(len_offset))
+					}
+
+					self.push_local(len_name.clone(), Some(offset_len_expr));
 
 					if self.checks {
 						self.push_range_check(len_expr.clone(), *range);

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -103,11 +103,11 @@ impl Des<'_> {
 					self.push_assign(into, self.readstring(len.into()));
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let len_numty = range.numty().unwrap_or_default();
+					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
 
 					self.push_local(
 						len_name.clone(),
-						Some(self.readnumty(len_numty.numty).add(Expr::Num(len_numty.offset))),
+						Some(self.readnumty(len_numty).add(Expr::Num(len_offset))),
 					);
 
 					if self.checks {
@@ -123,11 +123,11 @@ impl Des<'_> {
 					self.push_read_copy(into, len.into());
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let len_numty = range.numty().unwrap_or_default();
+					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
 
 					self.push_local(
 						len_name.clone(),
-						Some(self.readnumty(len_numty.numty).add(Expr::Num(len_numty.offset))),
+						Some(self.readnumty(len_numty).add(Expr::Num(len_offset))),
 					);
 
 					if self.checks {
@@ -154,11 +154,11 @@ impl Des<'_> {
 					self.push_stmt(Stmt::End);
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let len_numty = range.numty().unwrap_or_default();
+					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
 
 					self.push_local(
 						len_name.clone(),
-						Some(self.readnumty(len_numty.numty).add(Expr::Num(len_numty.offset))),
+						Some(self.readnumty(len_numty).add(Expr::Num(len_offset))),
 					);
 
 					if self.checks {

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -373,6 +373,7 @@ pub enum Expr {
 
 	// Arithmetic Binary Operators
 	Add(Box<Expr>, Box<Expr>),
+	Sub(Box<Expr>, Box<Expr>),
 	Mul(Box<Expr>, Box<Expr>),
 }
 
@@ -419,6 +420,10 @@ impl Expr {
 
 	pub fn add(self, other: Self) -> Self {
 		Self::Add(Box::new(self), Box::new(other))
+	}
+
+	pub fn sub(self, other: Self) -> Self {
+		Self::Sub(Box::new(self), Box::new(other))
 	}
 }
 
@@ -508,6 +513,7 @@ impl Display for Expr {
 			Self::Eq(lhs, rhs) => write!(f, "{} == {}", lhs, rhs),
 
 			Self::Add(lhs, rhs) => write!(f, "{} + {}", lhs, rhs),
+			Self::Sub(lhs, rhs) => write!(f, "{} - {}", lhs, rhs),
 			Self::Mul(lhs, rhs) => write!(f, "{} * {}", lhs, rhs),
 		}
 	}

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -113,7 +113,12 @@ impl Ser<'_> {
 						self.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_offset)), len_numty);
+					let mut offset_len_expr = len_expr.clone();
+					if len_offset != 0.0 {
+						offset_len_expr = offset_len_expr.sub(Expr::Num(len_offset))
+					}
+
+					self.push_writenumty(offset_len_expr, len_numty);
 					self.push_writestring(from_expr, len_expr.clone());
 				}
 			}
@@ -144,7 +149,12 @@ impl Ser<'_> {
 						self.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_offset)), len_numty);
+					let mut offset_len_expr = len_expr.clone();
+					if len_offset != 0.0 {
+						offset_len_expr = offset_len_expr.sub(Expr::Num(len_offset))
+					}
+
+					self.push_writenumty(offset_len_expr, len_numty);
 					self.push_write_copy(from_expr, len_name.as_str().into())
 				}
 			}
@@ -175,7 +185,12 @@ impl Ser<'_> {
 						self.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_offset)), len_numty);
+					let mut offset_len_expr = len_expr.clone();
+					if len_offset != 0.0 {
+						offset_len_expr = offset_len_expr.sub(Expr::Num(len_offset))
+					}
+
+					self.push_writenumty(offset_len_expr, len_numty);
 
 					self.push_stmt(Stmt::NumFor {
 						var: var_name.clone(),

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -41,7 +41,7 @@ impl Ser<'_> {
 		match enum_ty {
 			Enum::Unit(enumerators) => {
 				let from_expr = Expr::from(from.clone());
-				let numty = NumTy::from_f64(0.0, enumerators.len() as f64 - 1.0);
+				let numty = NumTy::from_f64_max(enumerators.len() as f64 - 1.0);
 
 				for (i, enumerator) in enumerators.iter().enumerate() {
 					if i == 0 {
@@ -62,7 +62,7 @@ impl Ser<'_> {
 
 			Enum::Tagged { tag, variants } => {
 				let tag_expr = Expr::from(from.clone().eindex(Expr::Str((*tag).into())));
-				let numty = NumTy::from_f64(0.0, variants.len() as f64 - 1.0);
+				let numty = NumTy::from_f64_max(variants.len() as f64 - 1.0);
 
 				for (i, variant) in variants.iter().enumerate() {
 					if i == 0 {
@@ -105,13 +105,15 @@ impl Ser<'_> {
 					self.push_writestring(from_expr, len.into());
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
+					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
+
 					self.push_local(len_name.clone(), Some(from_expr.clone().len()));
 
 					if self.checks {
 						self.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_writenumty(len_expr.clone(), range.numty().unwrap_or(NumTy::U16));
+					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_offset)), len_numty);
 					self.push_writestring(from_expr, len_expr.clone());
 				}
 			}
@@ -131,6 +133,8 @@ impl Ser<'_> {
 					self.push_write_copy(from_expr, len.into());
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
+					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
+
 					self.push_local(
 						len_name.clone(),
 						Some(Var::from("buffer").nindex("len").call(vec![from_expr.clone()])),
@@ -140,7 +144,7 @@ impl Ser<'_> {
 						self.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_writenumty(len_expr.clone(), range.numty().unwrap_or(NumTy::U16));
+					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_offset)), len_numty);
 					self.push_write_copy(from_expr, len_name.as_str().into())
 				}
 			}
@@ -163,13 +167,15 @@ impl Ser<'_> {
 					self.push_stmt(Stmt::End);
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
+					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
+
 					self.push_local(len_name.clone(), Some(from_expr.clone().len()));
 
 					if self.checks {
 						self.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_writenumty(len_expr.clone(), range.numty().unwrap_or(NumTy::U16));
+					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_offset)), len_numty);
 
 					self.push_stmt(Stmt::NumFor {
 						var: var_name.clone(),

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -105,7 +105,7 @@ impl Ser<'_> {
 					self.push_writestring(from_expr, len.into());
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
+					let (len_numty, len_offset) = range.numty();
 
 					self.push_local(len_name.clone(), Some(from_expr.clone().len()));
 
@@ -138,7 +138,7 @@ impl Ser<'_> {
 					self.push_write_copy(from_expr, len.into());
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
+					let (len_numty, len_offset) = range.numty();
 
 					self.push_local(
 						len_name.clone(),
@@ -177,7 +177,7 @@ impl Ser<'_> {
 					self.push_stmt(Stmt::End);
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
+					let (len_numty, len_offset) = range.numty();
 
 					self.push_local(len_name.clone(), Some(from_expr.clone().len()));
 

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -41,7 +41,7 @@ impl Ser<'_> {
 		match enum_ty {
 			Enum::Unit(enumerators) => {
 				let from_expr = Expr::from(from.clone());
-				let numty = NumTy::from_f64_max(enumerators.len() as f64 - 1.0);
+				let numty = NumTy::from_f64(0.0, enumerators.len() as f64 - 1.0);
 
 				for (i, enumerator) in enumerators.iter().enumerate() {
 					if i == 0 {
@@ -62,7 +62,7 @@ impl Ser<'_> {
 
 			Enum::Tagged { tag, variants } => {
 				let tag_expr = Expr::from(from.clone().eindex(Expr::Str((*tag).into())));
-				let numty = NumTy::from_f64_max(variants.len() as f64 - 1.0);
+				let numty = NumTy::from_f64(0.0, variants.len() as f64 - 1.0);
 
 				for (i, variant) in variants.iter().enumerate() {
 					if i == 0 {
@@ -105,7 +105,7 @@ impl Ser<'_> {
 					self.push_writestring(from_expr, len.into());
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
+					let len_numty = range.numty().unwrap_or_default();
 
 					self.push_local(len_name.clone(), Some(from_expr.clone().len()));
 
@@ -113,7 +113,7 @@ impl Ser<'_> {
 						self.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_offset)), len_numty);
+					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_numty.offset)), len_numty.numty);
 					self.push_writestring(from_expr, len_expr.clone());
 				}
 			}
@@ -133,7 +133,7 @@ impl Ser<'_> {
 					self.push_write_copy(from_expr, len.into());
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
+					let len_numty = range.numty().unwrap_or_default();
 
 					self.push_local(
 						len_name.clone(),
@@ -144,7 +144,7 @@ impl Ser<'_> {
 						self.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_offset)), len_numty);
+					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_numty.offset)), len_numty.numty);
 					self.push_write_copy(from_expr, len_name.as_str().into())
 				}
 			}
@@ -167,7 +167,7 @@ impl Ser<'_> {
 					self.push_stmt(Stmt::End);
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
+					let len_numty = range.numty().unwrap_or_default();
 
 					self.push_local(len_name.clone(), Some(from_expr.clone().len()));
 
@@ -175,7 +175,7 @@ impl Ser<'_> {
 						self.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_offset)), len_numty);
+					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_numty.offset)), len_numty.numty);
 
 					self.push_stmt(Stmt::NumFor {
 						var: var_name.clone(),

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -105,7 +105,7 @@ impl Ser<'_> {
 					self.push_writestring(from_expr, len.into());
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let len_numty = range.numty().unwrap_or_default();
+					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
 
 					self.push_local(len_name.clone(), Some(from_expr.clone().len()));
 
@@ -113,7 +113,7 @@ impl Ser<'_> {
 						self.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_numty.offset)), len_numty.numty);
+					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_offset)), len_numty);
 					self.push_writestring(from_expr, len_expr.clone());
 				}
 			}
@@ -133,7 +133,7 @@ impl Ser<'_> {
 					self.push_write_copy(from_expr, len.into());
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let len_numty = range.numty().unwrap_or_default();
+					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
 
 					self.push_local(
 						len_name.clone(),
@@ -144,7 +144,7 @@ impl Ser<'_> {
 						self.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_numty.offset)), len_numty.numty);
+					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_offset)), len_numty);
 					self.push_write_copy(from_expr, len_name.as_str().into())
 				}
 			}
@@ -167,7 +167,7 @@ impl Ser<'_> {
 					self.push_stmt(Stmt::End);
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
-					let len_numty = range.numty().unwrap_or_default();
+					let (len_numty, len_offset) = range.numty().unwrap_or((NumTy::U16, 0.0));
 
 					self.push_local(len_name.clone(), Some(from_expr.clone().len()));
 
@@ -175,7 +175,7 @@ impl Ser<'_> {
 						self.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_numty.offset)), len_numty.numty);
+					self.push_writenumty(len_expr.clone().sub(Expr::Num(len_offset)), len_numty);
 
 					self.push_stmt(Stmt::NumFor {
 						var: var_name.clone(),


### PR DESCRIPTION
This PR makes the NumTy algorithm smarter by storing only the offset from the minimum value of the range. This means that `[255..265]` will now store a `u8` of `[0, 10]` and 255 will be added or subtracted as needed.