### PR TITLE
Add messages to asserts

### DIFF
--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -257,7 +257,7 @@ impl Des<'_> {
 									Some("IsA".into()),
 									vec![Expr::Str(class.unwrap().into())],
 								)),
-								None,
+								format!("received instance is not of the {} class!", class.unwrap()),
 							)
 						}
 					}
@@ -312,7 +312,7 @@ impl Des<'_> {
 
 				// always assert non-optional instances as roblox
 				// will sometimes vaporize them
-				self.push_assert(into_expr.clone().neq(Expr::Nil), None);
+				self.push_assert(into_expr.clone().neq(Expr::Nil), "received instance is nil!".into());
 
 				if self.checks && class.is_some() {
 					self.push_assert(
@@ -321,7 +321,7 @@ impl Des<'_> {
 							Some("IsA".into()),
 							vec![Expr::Str(class.unwrap().into())],
 						),
-						None,
+						format!("received instance is not of the {} class!", class.unwrap()),
 					)
 				}
 			}

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -21,7 +21,7 @@ pub trait Gen {
 		self.push_stmt(Stmt::Assign(var, expr))
 	}
 
-	fn push_assert(&mut self, expr: Expr, msg: Option<String>) {
+	fn push_assert(&mut self, expr: Expr, msg: String) {
 		self.push_stmt(Stmt::Assert(expr, msg))
 	}
 
@@ -248,11 +248,11 @@ pub trait Gen {
 
 	fn push_range_check(&mut self, expr: Expr, range: Range) {
 		if let Some(min) = range.min() {
-			self.push_assert(expr.clone().gte(min.into()), None)
+			self.push_assert(expr.clone().gte(min.into()), format!("value is less than {min}!"))
 		}
 
 		if let Some(max) = range.max() {
-			self.push_assert(expr.clone().lte(max.into()), None)
+			self.push_assert(expr.clone().lte(max.into()), format!("value is more than {max}!"))
 		}
 	}
 
@@ -280,7 +280,7 @@ pub enum Stmt {
 	LocalTuple(Vec<String>, Option<Expr>),
 	Assign(Var, Expr),
 	Error(String),
-	Assert(Expr, Option<String>),
+	Assert(Expr, String),
 
 	Call(Var, Option<String>, Vec<Expr>),
 

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -99,7 +99,10 @@ impl Ser<'_> {
 			Ty::Str(range) => {
 				if let Some(len) = range.exact() {
 					if self.checks {
-						self.push_assert(from_expr.clone().len().eq(len.into()), None);
+						self.push_assert(
+							from_expr.clone().len().eq(len.into()),
+							format!("length is not equal to {len}!"),
+						);
 					}
 
 					self.push_writestring(from_expr, len.into());
@@ -131,7 +134,7 @@ impl Ser<'_> {
 								.nindex("len")
 								.call(vec![from_expr.clone()])
 								.eq(len.into()),
-							None,
+							format!("length is not equal to {len}!"),
 						);
 					}
 
@@ -164,7 +167,10 @@ impl Ser<'_> {
 
 				if let Some(len) = range.exact() {
 					if self.checks {
-						self.push_assert(from_expr.clone().len().eq(len.into()), None);
+						self.push_assert(
+							from_expr.clone().len().eq(len.into()),
+							format!("length is not equal to {len}!"),
+						);
 					}
 
 					self.push_stmt(Stmt::NumFor {
@@ -307,7 +313,7 @@ impl Ser<'_> {
 							Some("IsA".into()),
 							vec![Expr::Str(class.unwrap().into())],
 						),
-						None,
+						format!("received instance is not of the {} class!", class.unwrap()),
 					);
 				}
 
@@ -402,10 +408,7 @@ impl Ser<'_> {
 					)),
 				);
 
-				self.push_assert(
-					axis_alignment_expr.clone(),
-					Some("CFrame not aligned to an axis!".to_string()),
-				);
+				self.push_assert(axis_alignment_expr.clone(), "CFrame not aligned to an axis!".into());
 
 				self.push_writeu8(axis_alignment_expr.clone());
 

--- a/zap/src/output/luau/mod.rs
+++ b/zap/src/output/luau/mod.rs
@@ -46,10 +46,7 @@ pub trait Output {
 
 			Stmt::Assign(var, expr) => self.push_line(&format!("{var} = {expr}")),
 			Stmt::Error(msg) => self.push_line(&format!("error(\"{msg}\")")),
-			Stmt::Assert(cond, msg) => match msg {
-				Some(msg) => self.push_line(&format!("assert({cond}, \"{msg}\")")),
-				None => self.push_line(&format!("assert({cond})")),
-			},
+			Stmt::Assert(cond, msg) => self.push_line(&format!("assert({cond}, \"{msg}\")")),
 
 			Stmt::Call(var, method, args) => match method {
 				Some(method) => self.push_line(&format!(

--- a/zap/src/output/tooling.rs
+++ b/zap/src/output/tooling.rs
@@ -73,10 +73,7 @@ impl<'src> ToolingOutput<'src> {
 
 			Stmt::Assign(var, expr) => self.push_line(&format!("{var} = {expr}")),
 			Stmt::Error(msg) => self.push_line(&format!("error(\"{msg}\")")),
-			Stmt::Assert(cond, msg) => match msg {
-				Some(msg) => self.push_line(&format!("assert({cond}, \"{msg}\")")),
-				None => self.push_line(&format!("assert({cond})")),
-			},
+			Stmt::Assert(cond, msg) => self.push_line(&format!("assert({cond}, \"{msg}\")")),
 
 			Stmt::Call(var, method, args) => match method {
 				Some(method) => self.push_line(&format!(

--- a/zap/tests/files/regression_184.zap
+++ b/zap/tests/files/regression_184.zap
@@ -1,0 +1,6 @@
+event Test = {
+    from: Client,
+    type: Reliable,
+    call: SingleSync,
+    data: Instance
+}

--- a/zap/tests/irgen/mod.rs
+++ b/zap/tests/irgen/mod.rs
@@ -132,7 +132,9 @@ impl<'src> TestOutput<'src> {
 		self.push_stmts(&des_statements);
 
 		for (ser_name, des_name) in ser_names.iter().zip(des_names.iter()) {
-			self.push_line(&format!("assert(deepEquals({ser_name}, {des_name}))"));
+			self.push_line(&format!(
+				r#"assert(deepEquals({ser_name}, {des_name}), "deserialised value differs from original!")"#
+			));
 		}
 
 		self.dedent();

--- a/zap/tests/lune/snapshots/run_lune_test@regression_184.snap
+++ b/zap/tests/lune/snapshots/run_lune_test@regression_184.snap
@@ -1,0 +1,8 @@
+---
+source: zap/tests/lune/mod.rs
+expression: result
+input_file: zap/tests/files/regression_184.zap
+---
+Ok(
+    0,
+)

--- a/zap/tests/selene/snapshots/run_selene_test@regression_184@client.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@regression_184@client.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: client_diagnostics
+input_file: zap/tests/files/regression_184.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@regression_184@server.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@regression_184@server.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: server_diagnostics
+input_file: zap/tests/files/regression_184.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@regression_184@tooling.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@regression_184@tooling.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: tooling_diagnostics
+input_file: zap/tests/files/regression_184.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@regression_184@types.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@regression_184@types.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: types_diagnostics
+input_file: zap/tests/files/regression_184.zap
+---
+[]


### PR DESCRIPTION
Adds & requires that asserts are given a message to ensure Selene tests pass and errors are easier to debug.