### PR TITLE
Fix regression in recursive type support

### DIFF
--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -14,9 +14,9 @@ impl Gen for Des<'_> {
 		self.buf.push(stmt);
 	}
 
-	fn gen<'a, I>(mut self, names: &[String], types: I) -> Vec<Stmt>
+	fn gen<'a, 'src: 'a, I>(mut self, names: &[String], types: I) -> Vec<Stmt>
 	where
-		I: Iterator<Item = &'a Ty<'a>>,
+		I: Iterator<Item = &'a Ty<'src>>,
 	{
 		for (ty, name) in types.zip(names) {
 			self.push_ty(ty, Var::Name(name.to_string()));
@@ -576,9 +576,14 @@ impl Des<'_> {
 	}
 }
 
-pub fn gen<'a, I>(types: I, names: &[String], checks: bool, var_occurrences: &mut HashMap<String, usize>) -> Vec<Stmt>
+pub fn gen<'a, 'src: 'a, I>(
+	types: I,
+	names: &[String],
+	checks: bool,
+	var_occurrences: &mut HashMap<String, usize>,
+) -> Vec<Stmt>
 where
-	I: IntoIterator<Item = &'a Ty<'a>>,
+	I: IntoIterator<Item = &'a Ty<'src>>,
 {
 	Des {
 		checks,

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -9,9 +9,9 @@ pub mod ser;
 
 pub trait Gen {
 	fn push_stmt(&mut self, stmt: Stmt);
-	fn gen<'a, I>(self, names: &[String], types: I) -> Vec<Stmt>
+	fn gen<'a, 'src: 'a, I>(self, names: &[String], types: I) -> Vec<Stmt>
 	where
-		I: Iterator<Item = &'a Ty<'a>>;
+		I: Iterator<Item = &'a Ty<'src>>;
 
 	fn push_local(&mut self, name: String, expr: Option<Expr>) {
 		self.push_stmt(Stmt::Local(name, expr))

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -14,9 +14,9 @@ impl Gen for Ser<'_> {
 		self.buf.push(stmt);
 	}
 
-	fn gen<'a, I>(mut self, names: &[String], types: I) -> Vec<Stmt>
+	fn gen<'a, 'src: 'a, I>(mut self, names: &[String], types: I) -> Vec<Stmt>
 	where
-		I: Iterator<Item = &'a Ty<'a>>,
+		I: Iterator<Item = &'a Ty<'src>>,
 	{
 		for (ty, name) in types.zip(names) {
 			self.push_ty(ty, Var::Name(name.to_string()));
@@ -561,9 +561,14 @@ impl Ser<'_> {
 	}
 }
 
-pub fn gen<'a, I>(types: I, names: &[String], checks: bool, var_occurrences: &mut HashMap<String, usize>) -> Vec<Stmt>
+pub fn gen<'a, 'src: 'a, I>(
+	types: I,
+	names: &[String],
+	checks: bool,
+	var_occurrences: &mut HashMap<String, usize>,
+) -> Vec<Stmt>
 where
-	I: IntoIterator<Item = &'a Ty<'a>>,
+	I: IntoIterator<Item = &'a Ty<'src>>,
 {
 	Ser {
 		checks,

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -136,7 +136,8 @@ impl<'src> ClientOutput<'src> {
 
 	fn push_tydecl(&mut self, tydecl: &TyDecl) {
 		let name = &tydecl.name;
-		let ty = &tydecl.ty;
+		let ty = tydecl.ty.borrow();
+		let ty = &*ty;
 
 		self.push_indent();
 		self.push(&format!("export type {name} = "));
@@ -1355,6 +1356,6 @@ impl<'src> ClientOutput<'src> {
 	}
 }
 
-pub fn code(config: &Config) -> String {
+pub fn code<'src>(config: &'src Config<'src>) -> String {
 	ClientOutput::new(config).output()
 }

--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -38,8 +38,8 @@ impl Output for ServerOutput<'_> {
 	}
 }
 
-impl<'a> ServerOutput<'a> {
-	pub fn new(config: &'a Config) -> Self {
+impl<'src> ServerOutput<'src> {
+	pub fn new(config: &'src Config<'src>) -> Self {
 		Self {
 			config,
 			tabs: 0,
@@ -122,7 +122,8 @@ impl<'a> ServerOutput<'a> {
 
 	fn push_tydecl(&mut self, tydecl: &TyDecl) {
 		let name = &tydecl.name;
-		let ty = &tydecl.ty;
+		let ty = tydecl.ty.borrow();
+		let ty = &*ty;
 
 		self.push_indent();
 		self.push(&format!("export type {name} = "));
@@ -1505,6 +1506,6 @@ impl<'a> ServerOutput<'a> {
 	}
 }
 
-pub fn code(config: &Config) -> String {
+pub fn code<'src>(config: &'src Config<'src>) -> String {
 	ServerOutput::new(config).output()
 }

--- a/zap/src/output/luau/types.rs
+++ b/zap/src/output/luau/types.rs
@@ -28,8 +28,8 @@ impl Output for TypesOutput<'_> {
 	}
 }
 
-impl<'a> TypesOutput<'a> {
-	pub fn new(config: &'a Config) -> Self {
+impl<'src> TypesOutput<'src> {
+	pub fn new(config: &'src Config<'src>) -> Self {
 		Self {
 			config,
 			tabs: 0,
@@ -39,7 +39,8 @@ impl<'a> TypesOutput<'a> {
 
 	fn push_tydecl(&mut self, tydecl: &TyDecl) {
 		let name = &tydecl.name;
-		let ty = &tydecl.ty;
+		let ty = tydecl.ty.borrow();
+		let ty = &*ty;
 
 		self.push_indent();
 		self.push(&format!("export type {name} = "));
@@ -66,6 +67,6 @@ impl<'a> TypesOutput<'a> {
 	}
 }
 
-pub fn code(config: &Config) -> String {
+pub fn code<'src>(config: &'src Config<'src>) -> String {
 	TypesOutput::new(config).output()
 }

--- a/zap/src/output/tooling.rs
+++ b/zap/src/output/tooling.rs
@@ -15,7 +15,7 @@ struct ToolingOutput<'src> {
 }
 
 impl<'src> ToolingOutput<'src> {
-	pub fn new(config: &'src Config) -> Self {
+	pub fn new(config: &'src Config<'src>) -> Self {
 		Self {
 			config,
 			tabs: 0,
@@ -112,7 +112,8 @@ impl<'src> ToolingOutput<'src> {
 
 	fn push_tydecl(&mut self, tydecl: &TyDecl) {
 		let name = &tydecl.name;
-		let ty = &tydecl.ty;
+		let ty = tydecl.ty.borrow();
+		let ty = &*ty;
 
 		self.push_line(&format!("function types.read_{name}()"));
 		self.indent();
@@ -585,7 +586,7 @@ impl<'src> ToolingOutput<'src> {
 	}
 }
 
-pub fn code(config: &Config) -> Option<Output> {
+pub fn code<'src>(config: &'src Config<'src>) -> Option<Output> {
 	if !config.tooling {
 		return None;
 	}

--- a/zap/src/output/typescript/client.rs
+++ b/zap/src/output/typescript/client.rs
@@ -9,7 +9,7 @@ struct ClientOutput<'src> {
 	buf: String,
 }
 
-impl Output for ClientOutput<'_> {
+impl<'src> Output<'src> for ClientOutput<'src> {
 	fn push(&mut self, s: &str) {
 		self.buf.push_str(s);
 	}
@@ -29,8 +29,8 @@ impl Output for ClientOutput<'_> {
 	}
 }
 
-impl ConfigProvider for ClientOutput<'_> {
-	fn get_config(&self) -> &Config {
+impl<'src> ConfigProvider<'src> for ClientOutput<'src> {
+	fn get_config(&self) -> &'src Config<'src> {
 		self.config
 	}
 }
@@ -46,7 +46,8 @@ impl<'src> ClientOutput<'src> {
 
 	fn push_tydecl(&mut self, tydecl: &TyDecl) {
 		let name = &tydecl.name;
-		let ty = &tydecl.ty;
+		let ty = tydecl.ty.borrow();
+		let ty = &*ty;
 
 		self.push_indent();
 		self.push(&format!("type {name} = "));
@@ -229,7 +230,7 @@ impl<'src> ClientOutput<'src> {
 	}
 }
 
-pub fn code(config: &Config) -> Option<String> {
+pub fn code<'src>(config: &'src Config<'src>) -> Option<String> {
 	if !config.typescript {
 		return None;
 	}

--- a/zap/src/output/typescript/mod.rs
+++ b/zap/src/output/typescript/mod.rs
@@ -4,11 +4,11 @@ pub mod client;
 pub mod server;
 pub mod types;
 
-pub trait ConfigProvider {
-	fn get_config(&self) -> &Config;
+pub trait ConfigProvider<'src> {
+	fn get_config(&self) -> &'src Config<'src>;
 }
 
-pub trait Output: ConfigProvider {
+pub trait Output<'src>: ConfigProvider<'src> {
 	fn push(&mut self, s: &str);
 	fn indent(&mut self);
 	fn dedent(&mut self);

--- a/zap/src/output/typescript/server.rs
+++ b/zap/src/output/typescript/server.rs
@@ -9,7 +9,7 @@ struct ServerOutput<'src> {
 	buf: String,
 }
 
-impl Output for ServerOutput<'_> {
+impl<'src> Output<'src> for ServerOutput<'src> {
 	fn push(&mut self, s: &str) {
 		self.buf.push_str(s);
 	}
@@ -29,14 +29,14 @@ impl Output for ServerOutput<'_> {
 	}
 }
 
-impl ConfigProvider for ServerOutput<'_> {
-	fn get_config(&self) -> &Config {
+impl<'src> ConfigProvider<'src> for ServerOutput<'src> {
+	fn get_config(&self) -> &'src Config<'src> {
 		self.config
 	}
 }
 
-impl<'a> ServerOutput<'a> {
-	pub fn new(config: &'a Config) -> Self {
+impl<'src> ServerOutput<'src> {
+	pub fn new(config: &'src Config<'src>) -> Self {
 		Self {
 			config,
 			tabs: 0,
@@ -46,7 +46,8 @@ impl<'a> ServerOutput<'a> {
 
 	fn push_tydecl(&mut self, tydecl: &TyDecl) {
 		let name = &tydecl.name;
-		let ty = &tydecl.ty;
+		let ty = tydecl.ty.borrow();
+		let ty = &*ty;
 
 		self.push_indent();
 		self.push(&format!("type {name} = "));
@@ -302,7 +303,7 @@ impl<'a> ServerOutput<'a> {
 	}
 }
 
-pub fn code(config: &Config) -> Option<String> {
+pub fn code<'src>(config: &'src Config<'src>) -> Option<String> {
 	if !config.typescript {
 		return None;
 	}

--- a/zap/src/output/typescript/types.rs
+++ b/zap/src/output/typescript/types.rs
@@ -8,7 +8,7 @@ struct TypesOutput<'src> {
 	buf: String,
 }
 
-impl Output for TypesOutput<'_> {
+impl<'src> Output<'src> for TypesOutput<'src> {
 	fn push(&mut self, s: &str) {
 		self.buf.push_str(s);
 	}
@@ -28,14 +28,14 @@ impl Output for TypesOutput<'_> {
 	}
 }
 
-impl ConfigProvider for TypesOutput<'_> {
-	fn get_config(&self) -> &Config {
+impl<'src> ConfigProvider<'src> for TypesOutput<'src> {
+	fn get_config(&self) -> &'src Config<'src> {
 		self.config
 	}
 }
 
-impl<'a> TypesOutput<'a> {
-	pub fn new(config: &'a Config) -> Self {
+impl<'src> TypesOutput<'src> {
+	pub fn new(config: &'src Config<'src>) -> Self {
 		Self {
 			config,
 			tabs: 0,
@@ -45,7 +45,8 @@ impl<'a> TypesOutput<'a> {
 
 	fn push_tydecl(&mut self, tydecl: &TyDecl) {
 		let name = &tydecl.name;
-		let ty = &tydecl.ty;
+		let ty = tydecl.ty.borrow();
+		let ty = &*ty;
 
 		self.push_indent();
 		self.push(&format!("export type {name} = "));
@@ -71,7 +72,7 @@ impl<'a> TypesOutput<'a> {
 	}
 }
 
-pub fn code(config: &Config) -> Option<String> {
+pub fn code<'src>(config: &'src Config<'src>) -> Option<String> {
 	if !config.typescript {
 		return None;
 	}

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -1,6 +1,8 @@
 use std::{
+	cell::RefCell,
 	cmp::Ordering,
 	collections::{HashMap, HashSet, VecDeque},
+	rc::Rc,
 };
 
 use crate::config::{
@@ -19,6 +21,7 @@ pub const MAX_UNRELIABLE_SIZE: usize = 998;
 struct Converter<'src> {
 	config: SyntaxConfig<'src>,
 	tydecls: HashMap<&'src str, SyntaxTyDecl<'src>>,
+	resolved_tys: HashMap<&'src str, Rc<RefCell<Ty<'src>>>>,
 
 	reports: Vec<Report<'src>>,
 }
@@ -36,6 +39,7 @@ impl<'src> Converter<'src> {
 		Self {
 			config,
 			tydecls,
+			resolved_tys: Default::default(),
 
 			reports: Vec::new(),
 		}
@@ -524,7 +528,15 @@ impl<'src> Converter<'src> {
 
 	fn tydecl(&mut self, tydecl: &SyntaxTyDecl<'src>) -> TyDecl<'src> {
 		let name = tydecl.name.name;
-		let ty = self.ty(&tydecl.ty);
+		let ty = if let Some(ty) = self.resolved_tys.get(name) {
+			ty.clone()
+		} else {
+			let cache_ty = Rc::new(RefCell::new(Ty::Opt(Box::new(Ty::Unknown))));
+			self.resolved_tys.insert(name, cache_ty.clone());
+			let ty = self.ty(&tydecl.ty);
+			cache_ty.replace(ty);
+			cache_ty
+		};
 
 		if let Some(ref_ty) = self.ty_has_unbounded_ref(name, &tydecl.ty, &mut HashSet::new()) {
 			self.report(Report::AnalyzeUnboundedRecursiveType {
@@ -683,10 +695,10 @@ impl<'src> Converter<'src> {
 								name,
 							});
 
-							return Ty::Ref(name, Box::new(Ty::Opt(Box::new(Ty::Unknown))));
+							return Ty::Ref(name, Rc::new(RefCell::new(Ty::Opt(Box::new(Ty::Unknown)))));
 						};
 
-						Ty::Ref(name, Box::new(self.tydecl(&tydecl).ty))
+						Ty::Ref(name, self.tydecl(&tydecl).ty)
 					}
 				}
 			}

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -531,19 +531,19 @@ impl<'src> Converter<'src> {
 		let ty = if let Some(ty) = self.resolved_tys.get(name) {
 			ty.clone()
 		} else {
+			if let Some(ref_ty) = self.ty_has_unbounded_ref(name, &tydecl.ty, &mut HashSet::new()) {
+				self.report(Report::AnalyzeUnboundedRecursiveType {
+					decl_span: tydecl.span(),
+					use_span: ref_ty.span(),
+				});
+			}
+
 			let cache_ty = Rc::new(RefCell::new(Ty::Opt(Box::new(Ty::Unknown))));
 			self.resolved_tys.insert(name, cache_ty.clone());
 			let ty = self.ty(&tydecl.ty);
 			cache_ty.replace(ty);
 			cache_ty
 		};
-
-		if let Some(ref_ty) = self.ty_has_unbounded_ref(name, &tydecl.ty, &mut HashSet::new()) {
-			self.report(Report::AnalyzeUnboundedRecursiveType {
-				decl_span: tydecl.span(),
-				use_span: ref_ty.span(),
-			});
-		}
 
 		TyDecl { name, ty }
 	}

--- a/zap/tests/files/recursive.zap
+++ b/zap/tests/files/recursive.zap
@@ -1,0 +1,17 @@
+-- type foo = foo
+
+-- event Simple = {
+--     from: Client,
+--     type: Reliable,
+--     call: SingleSync,
+--     data: foo
+-- }
+
+type bar = struct { baz: bar? }
+
+event Complex = {
+    from: Client,
+    type: Reliable,
+    call: SingleSync,
+    data: bar
+}

--- a/zap/tests/irgen/mod.rs
+++ b/zap/tests/irgen/mod.rs
@@ -49,7 +49,8 @@ impl<'src> TestOutput<'src> {
 
 	fn push_tydecl(&mut self, tydecl: &TyDecl) {
 		let name = &tydecl.name;
-		let ty = &tydecl.ty;
+		let ty = tydecl.ty.borrow();
+		let ty = &*ty;
 
 		self.push_indent();
 		self.push(&format!("export type {name} = "));

--- a/zap/tests/irgen/mod.rs
+++ b/zap/tests/irgen/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use insta::{assert_debug_snapshot, Settings};
 use lune::Runtime;
 use zap::{
 	config::{Config, Parameter, TyDecl},
@@ -404,4 +405,27 @@ async fn test_or_complex() {
 	let mut runtime = Runtime::new();
 
 	runtime.run("Zap", output).await.unwrap();
+}
+
+#[test]
+fn test_unbounded_recursive_type() {
+	let input = r#"type foo = foo
+event Simple = {
+    from: Client,
+    type: Reliable,
+    call: SingleSync,
+    data: foo
+}"#;
+
+	let (config, reports) = parse(input);
+
+	assert!(config.is_some());
+	assert!(!reports.is_empty());
+
+	let mut insta_settings = Settings::new();
+	insta_settings.set_prepend_module_to_snapshot(false);
+	insta_settings.set_sort_maps(true);
+	insta_settings.set_input_file("unbounded_recursive_type.zap");
+
+	insta_settings.bind(|| assert_debug_snapshot!(reports))
 }

--- a/zap/tests/irgen/snapshots/unbounded_recursive_type.snap
+++ b/zap/tests/irgen/snapshots/unbounded_recursive_type.snap
@@ -1,0 +1,10 @@
+---
+source: zap/tests/irgen/mod.rs
+expression: reports
+---
+[
+    AnalyzeUnboundedRecursiveType {
+        decl_span: 0..14,
+        use_span: 11..14,
+    },
+]

--- a/zap/tests/lune/snapshots/run_lune_test@recursive.snap
+++ b/zap/tests/lune/snapshots/run_lune_test@recursive.snap
@@ -1,0 +1,8 @@
+---
+source: zap/tests/lune/mod.rs
+expression: result
+input_file: zap/tests/files/recursive.zap
+---
+Ok(
+    0,
+)

--- a/zap/tests/selene/snapshots/run_selene_test@recursive@client.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@recursive@client.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: client_diagnostics
+input_file: zap/tests/files/recursive.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@recursive@server.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@recursive@server.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: server_diagnostics
+input_file: zap/tests/files/recursive.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@recursive@tooling.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@recursive@tooling.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: tooling_diagnostics
+input_file: zap/tests/files/recursive.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@recursive@types.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@recursive@types.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: types_diagnostics
+input_file: zap/tests/files/recursive.zap
+---
+[]


### PR DESCRIPTION
Unfortunately, #172 introduced a regression which caused recursive types to overflow the stack. This PR fixes that by using a RefCell to update the type when resolved only once.