### PR TITLE
Loosen restrictions on set & list types

### DIFF
--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -902,7 +902,7 @@ impl<'a> ServerOutput<'a> {
 		let value = self.config.casing.with("Value", "value", "value");
 
 		self.push_indent();
-		self.push(&format!("{fire_list} = function({list}: {{ Player }}"));
+		self.push(&format!("{fire_list} = function({list}: {{ [unknown]: Player }}"));
 
 		if !parameters.is_empty() {
 			self.push(", ");
@@ -972,7 +972,7 @@ impl<'a> ServerOutput<'a> {
 		let value = self.config.casing.with("Value", "value", "value");
 
 		self.push_indent();
-		self.push(&format!("{fire_set} = function({set}: {{ [Player]: true }}"));
+		self.push(&format!("{fire_set} = function({set}: {{ [Player]: unknown }}"));
 
 		if !parameters.is_empty() {
 			self.push(", ");

--- a/zap/src/output/typescript/server.rs
+++ b/zap/src/output/typescript/server.rs
@@ -112,7 +112,9 @@ impl<'a> ServerOutput<'a> {
 		let list = self.config.casing.with("List", "list", "list");
 
 		self.push_indent();
-		self.push(&format!("{fire_list}: ({list}: Player[]"));
+		self.push(&format!(
+			"{fire_list}: ({list}: Player[] | Record<string | number | symbol, Player> | Map<unknown, Player>"
+		));
 
 		if !ev.data.is_empty() {
 			self.push(", ");
@@ -127,7 +129,7 @@ impl<'a> ServerOutput<'a> {
 		let set = self.config.casing.with("Set", "set", "set");
 
 		self.push_indent();
-		self.push(&format!("{fire_set}: ({set}: Set<Player>"));
+		self.push(&format!("{fire_set}: ({set}: Set<Player> | Map<Player, unknown>"));
 
 		if !ev.data.is_empty() {
 			self.push(", ");


### PR DESCRIPTION
Previously, fire_list only accepted arrays of players and fire_set accepted maps of player to true. With this PR, other types are accepted.