### PR TITLE
Fix TypeScript iteration

### DIFF
--- a/zap/src/output/typescript/client.rs
+++ b/zap/src/output/typescript/client.rs
@@ -109,7 +109,7 @@ impl<'src> ClientOutput<'src> {
 				let value = self.config.casing.with("Value", "value", "value");
 
 				self.push_indent();
-				self.push(&format!("{iter}: Iter<LuaTuple<[{index}: number"));
+				self.push(&format!("{iter}: () => IterableFunction<LuaTuple<[{index}: number"));
 
 				for (index, parameter) in ev.data.iter().enumerate() {
 					let name = match parameter.name {
@@ -215,10 +215,6 @@ impl<'src> ClientOutput<'src> {
 			self.push_line("export {}");
 			return self.buf;
 		};
-
-		if self.config.evdecls.iter().any(|ev| ev.call == EvCall::Polling) {
-			self.push_iter_type()
-		}
 
 		self.push_event_loop();
 

--- a/zap/src/output/typescript/mod.rs
+++ b/zap/src/output/typescript/mod.rs
@@ -268,12 +268,7 @@ pub trait Output: ConfigProvider {
 	}
 
 	fn push_iter_type(&mut self) {
-		self.push_line("type Iter<T> = () => {");
-		self.indent();
-		self.push_line("[Symbol.iterator](): Iterator<T>,");
-		self.push_line("(): T | undefined");
-		self.dedent();
-		self.push_line("}");
+		self.push_line("type Iter<T> = () => IterableFunction<T>");
 	}
 
 	fn push_event_loop(&mut self) {

--- a/zap/src/output/typescript/mod.rs
+++ b/zap/src/output/typescript/mod.rs
@@ -267,10 +267,6 @@ pub trait Output<'src>: ConfigProvider<'src> {
 		));
 	}
 
-	fn push_iter_type(&mut self) {
-		self.push_line("type Iter<T> = () => IterableFunction<T>");
-	}
-
 	fn push_event_loop(&mut self) {
 		let send_events = self.get_config().casing.with("SendEvents", "sendEvents", "send_events");
 

--- a/zap/src/output/typescript/server.rs
+++ b/zap/src/output/typescript/server.rs
@@ -184,7 +184,9 @@ impl<'src> ServerOutput<'src> {
 				let value = self.config.casing.with("Value", "value", "value");
 
 				self.push_indent();
-				self.push(&format!("{iter}: Iter<LuaTuple<[{index}: number, {player}: Player"));
+				self.push(&format!(
+					"{iter}: () => IterableFunction<LuaTuple<[{index}: number, {player}: Player"
+				));
 
 				for (index, parameter) in ev.data.iter().enumerate() {
 					let name = match parameter.name {
@@ -290,10 +292,6 @@ impl<'src> ServerOutput<'src> {
 			self.push_line("export {}");
 			return self.buf;
 		};
-
-		if self.config.evdecls.iter().any(|ev| ev.call == EvCall::Polling) {
-			self.push_iter_type()
-		}
 
 		self.push_event_loop();
 


### PR DESCRIPTION
roblox-ts doesn't seem to know how to iterate over `[Symbol.iterator]()`, but it does know how to iterate over `IterableFunction` (its own type, also used by e.g. pairs or ipairs). This PR changes the type to allow usage such as:
```typescript
for (const [id, data] of remotes.sendData.iter()) {
```