### PR TITLE
Separate is empty and length serde

### DIFF
--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -329,9 +329,13 @@ impl Des<'_> {
 			}
 
 			Ty::Map(key, val) => {
+				let (empty_bits, empty_var) = self.get_bitpack();
 				let length_numty = key.variants().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
 				self.push_assign(into.clone(), Expr::Table(Default::default()));
+
+				let empty_expr = self.check_bitfield(empty_bits, empty_var);
+				self.push_stmt(Stmt::If(empty_expr.not()));
 
 				self.push_stmt(Stmt::NumFor {
 					var: "_".into(),
@@ -354,12 +358,18 @@ impl Des<'_> {
 				self.end_scope();
 
 				self.push_stmt(Stmt::End);
+
+				self.push_stmt(Stmt::End);
 			}
 
 			Ty::Set(key) => {
+				let (empty_bits, empty_var) = self.get_bitpack();
 				let length_numty = key.variants().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
 				self.push_assign(into.clone(), Expr::Table(Default::default()));
+
+				let empty_expr = self.check_bitfield(empty_bits, empty_var);
+				self.push_stmt(Stmt::If(empty_expr.not()));
 
 				self.push_stmt(Stmt::NumFor {
 					var: "_".into(),
@@ -377,6 +387,8 @@ impl Des<'_> {
 				self.push_assign(into.clone().eindex(key_expr.clone()), Expr::True);
 
 				self.end_scope();
+
+				self.push_stmt(Stmt::End);
 
 				self.push_stmt(Stmt::End);
 			}

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -340,7 +340,7 @@ impl Des<'_> {
 				self.push_stmt(Stmt::NumFor {
 					var: "_".into(),
 					from: 1.0.into(),
-					to: self.readnumty(length_numty),
+					to: self.readnumty(length_numty).add(1.0.into()),
 				});
 
 				self.new_scope();
@@ -374,7 +374,7 @@ impl Des<'_> {
 				self.push_stmt(Stmt::NumFor {
 					var: "_".into(),
 					from: 1.0.into(),
-					to: self.readnumty(length_numty),
+					to: self.readnumty(length_numty).add(1.0.into()),
 				});
 
 				self.new_scope();

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -466,7 +466,11 @@ impl Ser<'_> {
 				self.push_stmt(Stmt::Call(
 					Var::from("buffer").nindex(format!("write{length_numty}")),
 					None,
-					vec!["outgoing_buff".into(), len_pos_expr.clone(), len_expr.clone()],
+					vec![
+						"outgoing_buff".into(),
+						len_pos_expr.clone(),
+						len_expr.clone().sub(1.0.into()),
+					],
 				));
 
 				self.push_stmt(Stmt::Else);
@@ -518,7 +522,11 @@ impl Ser<'_> {
 				self.push_stmt(Stmt::Call(
 					Var::from("buffer").nindex(format!("write{length_numty}")),
 					None,
-					vec!["outgoing_buff".into(), len_pos_expr.clone(), len_expr.clone()],
+					vec![
+						"outgoing_buff".into(),
+						len_pos_expr.clone(),
+						len_expr.clone().sub(1.0.into()),
+					],
 				));
 
 				self.push_stmt(Stmt::Else);

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -425,13 +425,11 @@ impl Ser<'_> {
 			Ty::Map(key, val) => {
 				let (len_name, len_expr) = self.add_occurrence("len");
 				let (len_pos_name, len_pos_expr) = self.add_occurrence("len_pos");
+				let (empty_bits, empty_var) = self.get_bitpack();
 
 				let length_numty = key.variants().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
-				self.push_local(
-					len_pos_name.clone(),
-					Some(Var::from("alloc").call(vec![(length_numty.size() as f64).into()])),
-				);
+				self.push_local(len_pos_name.clone(), None);
 				self.push_local(len_name.clone(), Some(0.0.into()));
 
 				let (key_name, _) = self.add_occurrence("k");
@@ -443,9 +441,19 @@ impl Ser<'_> {
 					obj: from_expr,
 				});
 
+				self.push_stmt(Stmt::If(len_expr.clone().eq(0.0.into())));
+
+				self.push_assign(
+					Var::Name(len_pos_name.clone()),
+					Var::from("alloc").call(vec![(length_numty.size() as f64).into()]),
+				);
+
+				self.push_stmt(Stmt::End);
+
 				self.new_scope();
 
 				self.push_assign(Var::Name(len_name.clone()), len_expr.clone().add(1.0.into()));
+
 				self.push_ty(key, key_name.as_str().into());
 				self.push_ty(val, val_name.as_str().into());
 
@@ -453,23 +461,29 @@ impl Ser<'_> {
 
 				self.push_stmt(Stmt::End);
 
+				self.push_stmt(Stmt::If(len_pos_expr.clone()));
+
 				self.push_stmt(Stmt::Call(
 					Var::from("buffer").nindex(format!("write{length_numty}")),
 					None,
 					vec!["outgoing_buff".into(), len_pos_expr.clone(), len_expr.clone()],
 				));
+
+				self.push_stmt(Stmt::Else);
+
+				self.set_bitfield(empty_bits, empty_var);
+
+				self.push_stmt(Stmt::End);
 			}
 
 			Ty::Set(key) => {
 				let (len_name, len_expr) = self.add_occurrence("len");
 				let (len_pos_name, len_pos_expr) = self.add_occurrence("len_pos");
+				let (empty_bits, empty_var) = self.get_bitpack();
 
 				let length_numty = key.variants().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
-				self.push_local(
-					len_pos_name.clone(),
-					Some(Var::from("alloc").call(vec![(length_numty.size() as f64).into()])),
-				);
+				self.push_local(len_pos_name.clone(), None);
 				self.push_local(len_name.clone(), Some(0.0.into()));
 
 				let (key_name, _) = self.add_occurrence("k");
@@ -481,6 +495,15 @@ impl Ser<'_> {
 					obj: from_expr,
 				});
 
+				self.push_stmt(Stmt::If(len_expr.clone().eq(0.0.into())));
+
+				self.push_assign(
+					Var::Name(len_pos_name.clone()),
+					Var::from("alloc").call(vec![(length_numty.size() as f64).into()]),
+				);
+
+				self.push_stmt(Stmt::End);
+
 				self.new_scope();
 
 				self.push_assign(Var::Name(len_name.clone()), len_expr.clone().add(1.0.into()));
@@ -490,11 +513,19 @@ impl Ser<'_> {
 
 				self.push_stmt(Stmt::End);
 
+				self.push_stmt(Stmt::If(len_pos_expr.clone()));
+
 				self.push_stmt(Stmt::Call(
 					Var::from("buffer").nindex(format!("write{length_numty}")),
 					None,
 					vec!["outgoing_buff".into(), len_pos_expr.clone(), len_expr.clone()],
 				));
+
+				self.push_stmt(Stmt::Else);
+
+				self.set_bitfield(empty_bits, empty_var);
+
+				self.push_stmt(Stmt::End);
 			}
 
 			Ty::Opt(ty) => {


### PR DESCRIPTION
Previously, to serialise all variants of `set { u8 }`/`map { [u8]: u8 }`, a u16 was used for the length. This was wasteful, as we only needed 1 more number to serialise whether the map is empty or not. Since now bitpacking is an option, the length is serialised as `[0, 255]` and 1 is added/subtracted on each side, and the emptiness is a bitflag.