### PR TITLE
Add precise string kinds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4401,6 +4401,7 @@ name = "zap"
 version = "0.6.23"
 dependencies = [
  "anyhow",
+ "bstr",
  "codespan-reporting 0.12.0",
  "full_moon",
  "insta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4401,7 +4401,6 @@ name = "zap"
 version = "0.6.23"
 dependencies = [
  "anyhow",
- "bstr",
  "codespan-reporting 0.12.0",
  "full_moon",
  "insta",

--- a/zap/Cargo.toml
+++ b/zap/Cargo.toml
@@ -28,3 +28,4 @@ selene-lib = "0.28.0"
 serde_yml = "0.0.12"
 tokio = { version = "1", features = ["full"] }
 toml = "0.8.19"
+bstr = "1.12.0"

--- a/zap/Cargo.toml
+++ b/zap/Cargo.toml
@@ -28,4 +28,3 @@ selene-lib = "0.28.0"
 serde_yml = "0.0.12"
 tokio = { version = "1", features = ["full"] }
 toml = "0.8.19"
-bstr = "1.12.0"

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -324,7 +324,7 @@ impl<'src> Ty<'src> {
 			Self::Num(numty, ..) => (numty.size(), Some(numty.size())),
 
 			Self::Str(utf8, len) => {
-				if !*utf8 && let Some(exact) = len.exact() {
+				if !utf8 && let Some(exact) = len.exact() {
 					(exact as usize, Some(exact as usize))
 				} else {
 					let (len_numty, ..) = len.numty();

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -272,7 +272,7 @@ impl Display for TyDecl<'_> {
 #[derive(Debug, Clone)]
 pub enum Ty<'src> {
 	Num(NumTy, Range),
-	Str(Range),
+	Str(bool, Range),
 	Buf(Range),
 	Vector(Box<Ty<'src>>, Box<Ty<'src>>, Option<Box<Ty<'src>>>),
 	Arr(Box<Ty<'src>>, Range),
@@ -323,8 +323,8 @@ impl<'src> Ty<'src> {
 		match self {
 			Self::Num(numty, ..) => (numty.size(), Some(numty.size())),
 
-			Self::Str(len) => {
-				if let Some(exact) = len.exact() {
+			Self::Str(utf8, len) => {
+				if !*utf8 && let Some(exact) = len.exact() {
 					(exact as usize, Some(exact as usize))
 				} else {
 					let (len_numty, ..) = len.numty();
@@ -650,6 +650,13 @@ impl Range {
 		};
 
 		(NumTy::from_f64(min, max), offset)
+	}
+
+	pub fn mul_max(mut self, rhs: f64) -> Self {
+		if let Some(max) = &mut self.max {
+			*max *= rhs;
+		}
+		self
 	}
 }
 

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -220,8 +220,8 @@ impl Des<'_> {
 				}
 			}
 
-			Ty::Str(range) => {
-				if let Some(len) = range.exact() {
+			Ty::Str(utf8, range) => {
+				if !*utf8 && let Some(len) = range.exact() {
 					self.push_assign(into, self.readstring(len.into()));
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
@@ -238,7 +238,11 @@ impl Des<'_> {
 						self.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_assign(into, self.readstring(len_expr.clone()));
+					self.push_assign(into.clone(), self.readstring(len_expr.clone()));
+
+					if *utf8 {
+						self.push_utf8_check(Expr::Var(into.into()));
+					}
 				}
 			}
 

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -221,7 +221,7 @@ impl Des<'_> {
 			}
 
 			Ty::Str(utf8, range) => {
-				if !*utf8 && let Some(len) = range.exact() {
+				if !utf8 && let Some(len) = range.exact() {
 					self.push_assign(into, self.readstring(len.into()));
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -255,6 +255,15 @@ pub trait Gen {
 		}
 	}
 
+	fn push_utf8_check(&mut self, expr: Expr) {
+		self.push_assert(
+			Var::NameIndex(Var::Name("utf8".into()).into(), "len".to_string())
+				.call(vec![expr.clone()])
+				.neq(Expr::Nil),
+			"value is not valid utf-8".into(),
+		);
+	}
+
 	fn get_var_occurrences(&mut self) -> &mut HashMap<String, usize>;
 	fn add_occurrence(&mut self, name: &str) -> (String, Expr) {
 		match self.get_var_occurrences().get(name) {

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -258,7 +258,7 @@ pub trait Gen {
 	fn push_utf8_check(&mut self, expr: Expr) {
 		self.push_assert(
 			Var::NameIndex(Var::Name("utf8".into()).into(), "len".to_string())
-				.call(vec![expr.clone()])
+				.call(vec![expr])
 				.neq(Expr::Nil),
 			"value is not valid utf-8".into(),
 		);

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -303,8 +303,8 @@ impl Ser<'_> {
 				self.push_writenumty(from_expr, *numty)
 			}
 
-			Ty::Str(range) => {
-				if let Some(len) = range.exact() {
+			Ty::Str(utf8, range) => {
+				if !*utf8 && let Some(len) = range.exact() {
 					if self.checks {
 						self.push_assert(
 							from_expr.clone().len().eq(len.into()),
@@ -321,6 +321,9 @@ impl Ser<'_> {
 
 					if self.checks {
 						self.push_range_check(len_expr.clone(), *range);
+						if *utf8 {
+							self.push_utf8_check(from_expr.clone());
+						}
 					}
 
 					let mut offset_len_expr = len_expr.clone();

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -304,7 +304,7 @@ impl Ser<'_> {
 			}
 
 			Ty::Str(utf8, range) => {
-				if !*utf8 && let Some(len) = range.exact() {
+				if !utf8 && let Some(len) = range.exact() {
 					if self.checks {
 						self.push_assert(
 							from_expr.clone().len().eq(len.into()),

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -716,7 +716,7 @@ impl<'src> Converter<'src> {
 
 			SyntaxTyKind::Str(kind, len) => {
 				if kind.is_none() {
-					self.report(Report::AnalyzeNoStringDataKind { span: ty.span() });
+					self.report(Report::DeprecationNoStringDataKind { span: ty.span() });
 				}
 
 				let utf8 = kind.unwrap_or(false);

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -714,10 +714,20 @@ impl<'src> Converter<'src> {
 					.unwrap_or_default(),
 			),
 
-			SyntaxTyKind::Str(len) => Ty::Str(
-				len.map(|range| self.checked_range_within(&range, 0.0, u16::MAX as f64))
-					.unwrap_or_default(),
-			),
+			SyntaxTyKind::Str(kind, len) => {
+				if kind.is_none() {
+					self.report(Report::AnalyzeNoStringDataKind { span: ty.span() });
+				}
+
+				let utf8 = kind.unwrap_or(false);
+
+				Ty::Str(
+					utf8,
+					len.map(|range| self.checked_range_within(&range, 0.0, u16::MAX as f64))
+						.unwrap_or_default()
+						.mul_max(if utf8 { 4.0 } else { 1.0 }),
+				)
+			}
 
 			SyntaxTyKind::Buf(len) => Ty::Buf(
 				len.map(|range| self.checked_range_within(&range, 0.0, u16::MAX as f64))

--- a/zap/src/parser/grammar.lalrpop
+++ b/zap/src/parser/grammar.lalrpop
@@ -108,7 +108,9 @@ TyKind: SyntaxTyKind<'input> = {
     "u16" <r:("(" <IntRange> ")")?> => SyntaxTyKind::Num(NumTy::U16, r),
     "u32" <r:("(" <IntRange> ")")?> => SyntaxTyKind::Num(NumTy::U32, r),
 
-    "string" <r:("(" <IntRange> ")")?> => SyntaxTyKind::Str(r),
+    "string" <r:("(" <IntRange> ")")?> => SyntaxTyKind::Str(None, r),
+    "string" "." "utf8" <r:("(" <IntRange> ")")?> => SyntaxTyKind::Str(Some(true), r),
+    "string" "." "binary" <r:("(" <IntRange> ")")?> => SyntaxTyKind::Str(Some(false), r),
     "buffer" <r:("(" <IntRange> ")")?> => SyntaxTyKind::Buf(r),
     "vector" => SyntaxTyKind::Vector(
         Box::new(SyntaxTy { start: 0, end: 0, kind: SyntaxTyKind::Num(NumTy::F32, None)}),
@@ -245,6 +247,8 @@ Identifier: SyntaxIdentifier<'input> = {
     <start:@L> "set" <end:@R> => SyntaxIdentifier { start, name: "set", end },
     <start:@L> "true" <end:@R> => SyntaxIdentifier { start, name: "true", end },
     <start:@L> "false" <end:@R> => SyntaxIdentifier { start, name: "false", end },
+    <start:@L> "utf8" <end:@R> => SyntaxIdentifier { start, name: "utf8", end },
+    <start:@L> "binary" <end:@R> => SyntaxIdentifier { start, name: "binary", end },
 }
 
 KeyIdentifier: SyntaxIdentifier<'input> = {

--- a/zap/src/parser/reports.rs
+++ b/zap/src/parser/reports.rs
@@ -143,6 +143,10 @@ pub enum Report<'src> {
 		span: Span,
 		name: &'src str,
 	},
+
+	AnalyzeNoStringDataKind {
+		span: Span,
+	},
 }
 
 impl Report<'_> {
@@ -178,6 +182,7 @@ impl Report<'_> {
 			Self::AnalyzeOrNestedOptional { .. } => Severity::Error,
 			Self::AnalyzeRecursiveOr { .. } => Severity::Error,
 			Self::AnalyzeConflictingExport { .. } => Severity::Error,
+			Self::AnalyzeNoStringDataKind { .. } => Severity::Warning,
 		}
 	}
 
@@ -216,6 +221,7 @@ impl Report<'_> {
 			Self::AnalyzeOrNestedOptional { .. } => "optional type used in OR".to_string(),
 			Self::AnalyzeRecursiveOr { .. } => "OR used recursively".to_string(),
 			Self::AnalyzeConflictingExport { name, .. } => format!("Zap exports {name} at the top level"),
+			Self::AnalyzeNoStringDataKind { .. } => "string data kind not declared".to_string(),
 		}
 	}
 
@@ -251,6 +257,7 @@ impl Report<'_> {
 			Self::AnalyzeOrNestedOptional { .. } => "3021",
 			Self::AnalyzeRecursiveOr { .. } => "3022",
 			Self::AnalyzeConflictingExport { .. } => "3023",
+			Self::AnalyzeNoStringDataKind { .. } => "3024",
 		}
 	}
 
@@ -389,6 +396,8 @@ impl Report<'_> {
 			],
 
 			Self::AnalyzeConflictingExport { span, .. } => vec![Label::primary((), span.clone())],
+
+			Self::AnalyzeNoStringDataKind { span } => vec![Label::primary((), span.clone())],
 		}
 	}
 
@@ -477,6 +486,10 @@ impl Report<'_> {
 			Self::AnalyzeConflictingExport { .. } => Some(vec![
 				"you will need to rename this declaration".to_string(),
 				"or move it inside a namespace".to_string(),
+			]),
+			Self::AnalyzeNoStringDataKind { .. } => Some(vec![
+				"specify either string.utf8 or string.binary (current behaviour)".to_string(),
+				"always use string.utf8 when dealing with data saved in datastores".to_string(),
 			]),
 		}
 	}

--- a/zap/src/parser/reports.rs
+++ b/zap/src/parser/reports.rs
@@ -144,7 +144,7 @@ pub enum Report<'src> {
 		name: &'src str,
 	},
 
-	AnalyzeNoStringDataKind {
+	DeprecationNoStringDataKind {
 		span: Span,
 	},
 }
@@ -182,7 +182,8 @@ impl Report<'_> {
 			Self::AnalyzeOrNestedOptional { .. } => Severity::Error,
 			Self::AnalyzeRecursiveOr { .. } => Severity::Error,
 			Self::AnalyzeConflictingExport { .. } => Severity::Error,
-			Self::AnalyzeNoStringDataKind { .. } => Severity::Warning,
+
+			Self::DeprecationNoStringDataKind { .. } => Severity::Warning,
 		}
 	}
 
@@ -221,7 +222,8 @@ impl Report<'_> {
 			Self::AnalyzeOrNestedOptional { .. } => "optional type used in OR".to_string(),
 			Self::AnalyzeRecursiveOr { .. } => "OR used recursively".to_string(),
 			Self::AnalyzeConflictingExport { name, .. } => format!("Zap exports {name} at the top level"),
-			Self::AnalyzeNoStringDataKind { .. } => "string data kind not declared".to_string(),
+
+			Self::DeprecationNoStringDataKind { .. } => "string data kind not declared".to_string(),
 		}
 	}
 
@@ -257,7 +259,8 @@ impl Report<'_> {
 			Self::AnalyzeOrNestedOptional { .. } => "3021",
 			Self::AnalyzeRecursiveOr { .. } => "3022",
 			Self::AnalyzeConflictingExport { .. } => "3023",
-			Self::AnalyzeNoStringDataKind { .. } => "3024",
+
+			Self::DeprecationNoStringDataKind { .. } => "4001",
 		}
 	}
 
@@ -397,7 +400,7 @@ impl Report<'_> {
 
 			Self::AnalyzeConflictingExport { span, .. } => vec![Label::primary((), span.clone())],
 
-			Self::AnalyzeNoStringDataKind { span } => vec![Label::primary((), span.clone())],
+			Self::DeprecationNoStringDataKind { span } => vec![Label::primary((), span.clone())],
 		}
 	}
 
@@ -487,7 +490,8 @@ impl Report<'_> {
 				"you will need to rename this declaration".to_string(),
 				"or move it inside a namespace".to_string(),
 			]),
-			Self::AnalyzeNoStringDataKind { .. } => Some(vec![
+			Self::DeprecationNoStringDataKind { .. } => Some(vec![
+				"this is deprecated and will be removed in a future release".to_string(),
 				"specify either string.utf8 or string.binary (current behaviour)".to_string(),
 				"always use string.utf8 when dealing with data saved in datastores".to_string(),
 			]),

--- a/zap/src/parser/syntax_tree.rs
+++ b/zap/src/parser/syntax_tree.rs
@@ -171,7 +171,7 @@ impl Spanned for Vec<SyntaxTy<'_>> {
 #[derive(Debug, Clone, PartialEq)]
 pub enum SyntaxTyKind<'src> {
 	Num(NumTy, Option<SyntaxRange<'src>>),
-	Str(Option<SyntaxRange<'src>>),
+	Str(Option<bool>, Option<SyntaxRange<'src>>),
 	Buf(Option<SyntaxRange<'src>>),
 	Vector(Box<SyntaxTy<'src>>, Box<SyntaxTy<'src>>, Option<Box<SyntaxTy<'src>>>),
 	Arr(Box<SyntaxTy<'src>>, Option<SyntaxRange<'src>>),

--- a/zap/tests/files/function.zap
+++ b/zap/tests/files/function.zap
@@ -1,5 +1,5 @@
 funct Test = {
     call: Async,
-    args: (Foo: u8, Bar: string),
-    rets: (enum { Success, Fail }, string)
+    args: (Foo: u8, Bar: string.binary),
+    rets: (enum { Success, Fail }, string.binary)
 }

--- a/zap/tests/files/function_mutiple_rets.zap
+++ b/zap/tests/files/function_mutiple_rets.zap
@@ -1,5 +1,5 @@
 funct MultipleRets = {
     call: Async,
     args: boolean,
-    rets: (enum { Success, Fail }, string)
+    rets: (enum { Success, Fail }, string.binary)
 }

--- a/zap/tests/files/function_two_unnamed_parameters.zap
+++ b/zap/tests/files/function_two_unnamed_parameters.zap
@@ -1,5 +1,5 @@
 funct TwoUnnamedParameters = {
     call: Async,
-    args: (u8, string),
+    args: (u8, string.binary),
     rets: enum { Success, Fail }
 }

--- a/zap/tests/files/namespaces.zap
+++ b/zap/tests/files/namespaces.zap
@@ -21,7 +21,7 @@ namespace NS = {
         from: Client,
         type: Reliable,
         call: SingleSync,
-        data: (Color3 | string | unknown)
+        data: (Color3 | string.binary | unknown)
     }
 }
 

--- a/zap/tests/files/nested_complex.zap
+++ b/zap/tests/files/nested_complex.zap
@@ -2,5 +2,5 @@ event NestedComplex = {
     from: Server,
     type: Reliable,
     call: SingleSync,
-    data: map { [map { [u8[]]: string }]: struct { x: u8 }[] },
+    data: map { [map { [u8[]]: string.binary }]: struct { x: u8 }[] },
 }

--- a/zap/tests/files/or_complex.zap
+++ b/zap/tests/files/or_complex.zap
@@ -2,7 +2,7 @@ event Test = {
     from: Client,
     type: Reliable,
     call: SingleSync,
-    data: (string | unknown | buffer | u16 | struct { bar: u8 } | enum { foo, bar, baz } | Instance (Part) | enum "test" {
+    data: (string.binary | unknown | buffer | u16 | struct { bar: u8 } | enum { foo, bar, baz } | Instance (Part) | enum "test" {
         a { 
             b: u8
         },

--- a/zap/tests/files/or_simple.zap
+++ b/zap/tests/files/or_simple.zap
@@ -2,5 +2,5 @@ event MyEvent = {
     from: Client,
     type: Reliable,
     call: SingleSync,
-    data: (u8 | string)
+    data: (u8 | string.binary)
 }

--- a/zap/tests/files/or_unknown.zap
+++ b/zap/tests/files/or_unknown.zap
@@ -2,5 +2,5 @@ event MyEvent = {
     from: Client,
     type: Reliable,
     call: SingleSync,
-    data: (u8 | string | unknown)
+    data: (u8 | string.binary | unknown)
 }

--- a/zap/tests/files/regression_153.zap
+++ b/zap/tests/files/regression_153.zap
@@ -1,5 +1,5 @@
 funct MultipleRets = {
     call: Async,
     args: boolean,
-    rets: (string, string, boolean)
+    rets: (string.binary, string.binary, boolean)
 }

--- a/zap/tests/files/simple_struct.zap
+++ b/zap/tests/files/simple_struct.zap
@@ -3,7 +3,7 @@ event MyEvent = {
     type: Reliable,
     call: ManyAsync,
     data: struct {
-        foo: string,
+        foo: string.binary,
         bar: u8,
     }
 }

--- a/zap/tests/files/string_kinds.zap
+++ b/zap/tests/files/string_kinds.zap
@@ -1,0 +1,13 @@
+event Binary = {
+    from: Client,
+    type: Reliable,
+    call: SingleSync,
+    data: string.binary
+}
+
+event Utf8 = {
+    from: Client,
+    type: Reliable,
+    call: SingleSync,
+    data: string.utf8
+}

--- a/zap/tests/files/struct_quoted_fields.zap
+++ b/zap/tests/files/struct_quoted_fields.zap
@@ -3,7 +3,7 @@ event MyEvent = {
     type: Reliable,
     call: ManyAsync,
     data: struct {
-        "foo bar": string,
+        "foo bar": string.binary,
         buzz: u8
     }
 }

--- a/zap/tests/files/tagged_enum_quoted.zap
+++ b/zap/tests/files/tagged_enum_quoted.zap
@@ -3,7 +3,7 @@ event MyEvent = {
     type: Reliable,
     call: ManyAsync,
     data: enum "tag with spaces" {
-        foo { "value with spaces": string, bar: u8 },
+        foo { "value with spaces": string.binary, bar: u8 },
         bar { buzz: u8 },
     }
 }

--- a/zap/tests/files/tuples.zap
+++ b/zap/tests/files/tuples.zap
@@ -2,5 +2,5 @@ event MyEvent = {
 	from: Server,
 	type: Reliable,
 	call: ManyAsync,
-	data: (Foo: boolean, Bar: u32, Baz: string)
+	data: (Foo: boolean, Bar: u32, Baz: string.binary)
 }

--- a/zap/tests/irgen/mod.rs
+++ b/zap/tests/irgen/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use bstr::BString;
 use insta::{Settings, assert_debug_snapshot};
 use lune::Runtime;
 use zap::{
@@ -470,4 +471,44 @@ async fn test_bitpacking() {
 	let mut runtime = Runtime::new();
 
 	runtime.run("Zap", output).await.unwrap();
+}
+
+const VALID_UTF8_STR: &str = r#""abcdefg1234ąśłź𒂓""#;
+
+#[tokio::test]
+async fn test_string_kinds() {
+	let (config, reports) = parse(include_str!("../files/string_kinds.zap"));
+
+	assert!(config.is_some());
+	assert!(reports.is_empty());
+
+	let invalid_utf = [
+		b"\xc3\x28".as_slice(),
+		b"\xa0\xa1".as_slice(),
+		b"\xe2\x28\xa1".as_slice(),
+		b"\xe2\x82\x28".as_slice(),
+		b"\xf0\x28\x8c\xbc".as_slice(),
+		b"\xf0\x90\x28\xbc".as_slice(),
+		b"\xf0\x28\x8c\x28".as_slice(),
+	]
+	.into_iter()
+	.map(|b| format!("{:?}", BString::from(b)))
+	.collect::<Vec<_>>();
+
+	let config = config.unwrap();
+
+	for (valid, bin_values, utf_values) in invalid_utf.iter().flat_map(|data| {
+		[
+			(true, vec![data.as_str()], vec![VALID_UTF8_STR]),
+			(false, vec![VALID_UTF8_STR], vec![data.as_str()]),
+		]
+	}) {
+		let default_values = HashMap::from([("Binary", bin_values), ("Utf8", utf_values)]);
+		let output = TestOutput::new(&config, default_values).output();
+		let mut runtime = Runtime::new();
+
+		if valid != runtime.run("Zap", output).await.is_ok() {
+			unreachable!()
+		}
+	}
 }

--- a/zap/tests/irgen/mod.rs
+++ b/zap/tests/irgen/mod.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use bstr::BString;
 use insta::{Settings, assert_debug_snapshot};
 use lune::Runtime;
 use zap::{
@@ -483,24 +482,21 @@ async fn test_string_kinds() {
 	assert!(reports.is_empty());
 
 	let invalid_utf = [
-		b"\xc3\x28".as_slice(),
-		b"\xa0\xa1".as_slice(),
-		b"\xe2\x28\xa1".as_slice(),
-		b"\xe2\x82\x28".as_slice(),
-		b"\xf0\x28\x8c\xbc".as_slice(),
-		b"\xf0\x90\x28\xbc".as_slice(),
-		b"\xf0\x28\x8c\x28".as_slice(),
-	]
-	.into_iter()
-	.map(|b| format!("{:?}", BString::from(b)))
-	.collect::<Vec<_>>();
+		r#""\xc3\x28""#,
+		r#""\xa0\xa1""#,
+		r#""\xe2\x28\xa1""#,
+		r#""\xe2\x82\x28""#,
+		r#""\xf0\x28\x8c\xbc""#,
+		r#""\xf0\x90\x28\xbc""#,
+		r#""\xf0\x28\x8c\x28""#,
+	];
 
 	let config = config.unwrap();
 
-	for (valid, bin_values, utf_values) in invalid_utf.iter().flat_map(|data| {
+	for (valid, bin_values, utf_values) in invalid_utf.into_iter().flat_map(|data| {
 		[
-			(true, vec![data.as_str()], vec![VALID_UTF8_STR]),
-			(false, vec![VALID_UTF8_STR], vec![data.as_str()]),
+			(true, vec![data], vec![VALID_UTF8_STR]),
+			(false, vec![VALID_UTF8_STR], vec![data]),
 		]
 	}) {
 		let default_values = HashMap::from([("Binary", bin_values), ("Utf8", utf_values)]);

--- a/zap/tests/lune/snapshots/run_lune_test@string_kinds.snap
+++ b/zap/tests/lune/snapshots/run_lune_test@string_kinds.snap
@@ -1,0 +1,8 @@
+---
+source: zap/tests/lune/mod.rs
+expression: result
+input_file: zap/tests/files/string_kinds.zap
+---
+Ok(
+    0,
+)

--- a/zap/tests/selene/snapshots/run_selene_test@string_kinds@client.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@string_kinds@client.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: client_diagnostics
+input_file: zap/tests/files/string_kinds.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@string_kinds@server.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@string_kinds@server.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: server_diagnostics
+input_file: zap/tests/files/string_kinds.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@string_kinds@tooling.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@string_kinds@tooling.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: tooling_diagnostics
+input_file: zap/tests/files/string_kinds.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@string_kinds@types.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@string_kinds@types.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: types_diagnostics
+input_file: zap/tests/files/string_kinds.zap
+---
+[]


### PR DESCRIPTION
Adds 2 new types: `string.utf8` and `string.binary`. `string` behaves the same as `string.binary`, although it is now deprecated & emits a warning when used - users are expected to explicitly choose `string.binary`.

`string.utf8` additionally checks for the string being valid UTF-8. The upper bound is now in characters - it gets multiplied by 4 because UTF-8 characters can take up to 4 bytes. This change is to prevent users from sending, e.g. 3-byte strings which may be too little for a UTF-8 string.
Since UTF-8 is a variable-width encoding, the length is always serialised, even if the range is exact.