### PR TITLE
Add path-like class specifiers for instances

### DIFF
--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -908,7 +908,17 @@ impl<'src> Converter<'src> {
 
 			SyntaxTyKind::Struct(struct_ty) => Ty::Struct(self.struct_ty(struct_ty)),
 
-			SyntaxTyKind::Instance(instance_ty) => Ty::Instance(instance_ty.as_ref().map(|ty| ty.name)),
+			SyntaxTyKind::Instance(old, instance_ty) => {
+				if *old {
+					self.report(Report::DeprecationOldInstanceClassSpecifier {
+						span: ty.span(),
+						// old is true only if it's present
+						name: instance_ty.unwrap().name,
+					});
+				}
+
+				Ty::Instance(instance_ty.as_ref().map(|ty| ty.name))
+			}
 
 			SyntaxTyKind::Or(or_tys) => self.or_ty(or_tys, false),
 		}

--- a/zap/src/parser/grammar.lalrpop
+++ b/zap/src/parser/grammar.lalrpop
@@ -133,7 +133,8 @@ TyKind: SyntaxTyKind<'input> = {
 
     "enum" <e:Enum> => SyntaxTyKind::Enum(e),
     "struct" <s:Struct> => SyntaxTyKind::Struct(s),
-    "Instance" <c:("(" <Identifier> ")")?> => SyntaxTyKind::Instance(c),
+    "Instance" <c:("." <Identifier>)?> => SyntaxTyKind::Instance(false, c),
+    "Instance" <c:("(" <Identifier> ")")> => SyntaxTyKind::Instance(true, Some(c)),
     
     "(" <ty:Ty> <mut tys:("|" <Ty>)+> ")" => {
         tys.insert(0, ty);

--- a/zap/src/parser/reports.rs
+++ b/zap/src/parser/reports.rs
@@ -147,6 +147,11 @@ pub enum Report<'src> {
 	DeprecationNoStringDataKind {
 		span: Span,
 	},
+
+	DeprecationOldInstanceClassSpecifier {
+		span: Span,
+		name: &'src str,
+	},
 }
 
 impl Report<'_> {
@@ -184,6 +189,7 @@ impl Report<'_> {
 			Self::AnalyzeConflictingExport { .. } => Severity::Error,
 
 			Self::DeprecationNoStringDataKind { .. } => Severity::Warning,
+			Self::DeprecationOldInstanceClassSpecifier { .. } => Severity::Warning,
 		}
 	}
 
@@ -224,6 +230,7 @@ impl Report<'_> {
 			Self::AnalyzeConflictingExport { name, .. } => format!("Zap exports {name} at the top level"),
 
 			Self::DeprecationNoStringDataKind { .. } => "string data kind not declared".to_string(),
+			Self::DeprecationOldInstanceClassSpecifier { .. } => "old instance class specifier used".to_string(),
 		}
 	}
 
@@ -261,6 +268,7 @@ impl Report<'_> {
 			Self::AnalyzeConflictingExport { .. } => "3023",
 
 			Self::DeprecationNoStringDataKind { .. } => "4001",
+			Self::DeprecationOldInstanceClassSpecifier { .. } => "4002",
 		}
 	}
 
@@ -401,6 +409,8 @@ impl Report<'_> {
 			Self::AnalyzeConflictingExport { span, .. } => vec![Label::primary((), span.clone())],
 
 			Self::DeprecationNoStringDataKind { span } => vec![Label::primary((), span.clone())],
+
+			Self::DeprecationOldInstanceClassSpecifier { span, .. } => vec![Label::primary((), span.clone())],
 		}
 	}
 
@@ -494,6 +504,10 @@ impl Report<'_> {
 				"this is deprecated and will be removed in a future release".to_string(),
 				"specify either string.utf8 or string.binary (current behaviour)".to_string(),
 				"always use string.utf8 when dealing with data saved in datastores".to_string(),
+			]),
+			Self::DeprecationOldInstanceClassSpecifier { name, .. } => Some(vec![
+				"this is deprecated and will be removed in a future release".to_string(),
+				format!("use the new syntax `Instance.{name}` instead"),
 			]),
 		}
 	}

--- a/zap/src/parser/syntax_tree.rs
+++ b/zap/src/parser/syntax_tree.rs
@@ -183,7 +183,7 @@ pub enum SyntaxTyKind<'src> {
 
 	Enum(SyntaxEnum<'src>),
 	Struct(SyntaxStruct<'src>),
-	Instance(Option<SyntaxIdentifier<'src>>),
+	Instance(bool, Option<SyntaxIdentifier<'src>>),
 	Or(Vec<SyntaxTy<'src>>),
 }
 

--- a/zap/tests/files/or_complex.zap
+++ b/zap/tests/files/or_complex.zap
@@ -2,7 +2,7 @@ event Test = {
     from: Client,
     type: Reliable,
     call: SingleSync,
-    data: (string.binary | unknown | buffer | u16 | struct { bar: u8 } | enum { foo, bar, baz } | Instance (Part) | enum "test" {
+    data: (string.binary | unknown | buffer | u16 | struct { bar: u8 } | enum { foo, bar, baz } | Instance.Part | enum "test" {
         a { 
             b: u8
         },


### PR DESCRIPTION
Brings new syntax `Instance.Player` to replace `Instance (Player)`. The new syntax looks much nicer when combined with other syntax: `Instance.Player[1..2]`, `Instance (Player)[1..2]`, `Instance.Player?`, `Instance (Player)?` as well as being more consistent.