### PR TITLE
Remove Ty::size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4408,6 +4408,7 @@ dependencies = [
  "lalrpop-util",
  "lune",
  "num-traits",
+ "paste",
  "selene-lib",
  "serde_yml",
  "tokio",

--- a/zap/Cargo.toml
+++ b/zap/Cargo.toml
@@ -18,6 +18,7 @@ codespan-reporting = "0.12.0"
 lalrpop-util = "0.22.2"
 num-traits = "0.2.17"
 wasm-bindgen = "0.2"
+paste = "1.0.15"
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -320,22 +320,6 @@ pub enum PrimitiveTy<'src> {
 }
 
 impl<'src> Ty<'src> {
-	pub fn size_known(&self) -> bool {
-		match self {
-			Ty::Struct(data) => data.fields.iter().all(|(_, ty)| ty.size_known()),
-			Ty::Enum(Enum::Tagged { variants, .. }) => variants
-				.iter()
-				.flat_map(|(_, data)| data.fields.iter())
-				.all(|(_, ty)| ty.size_known()),
-			Ty::Or(tys, _) => tys.iter().all(|ty| ty.size_known()),
-			Ty::Opt(ty) => ty.size_known(),
-			// recursive
-			Ty::Ref(..) => false,
-			Ty::Map(..) | Ty::Set(..) => false,
-			_ => true,
-		}
-	}
-
 	pub fn variants(&self) -> Option<(NumTy, usize)> {
 		match self {
 			Ty::Enum(Enum::Unit(variants)) => Some(variants.len()),

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -1,9 +1,6 @@
-use std::{
-	cell::RefCell,
-	collections::{BTreeMap, HashSet},
-	fmt::Display,
-	rc::Rc,
-};
+use std::{cell::RefCell, collections::BTreeMap, fmt::Display, rc::Rc};
+
+use crate::irgen::Stmt;
 
 pub const UNRELIABLE_ORDER_NUMTY: NumTy = NumTy::U16;
 
@@ -230,6 +227,7 @@ pub struct EvDecl<'src> {
 	pub data: Vec<Parameter<'src>>,
 	pub id: usize,
 	pub path: Vec<&'src str>,
+	pub serde: Option<(Vec<Stmt>, Vec<Stmt>)>,
 }
 
 #[derive(Debug, Clone)]
@@ -322,174 +320,19 @@ pub enum PrimitiveTy<'src> {
 }
 
 impl<'src> Ty<'src> {
-	/// Returns the amount of data used by this type in bytes.
-	///
-	/// Note that this is not the same as the size of the type in the buffer.
-	/// For example, an `Instance` will always send 4 bytes of data, but the
-	/// size of the type in the buffer will be 0 bytes.
-	pub fn size(&self, recursed: &mut HashSet<String>) -> (usize, Option<usize>) {
+	pub fn size_known(&self) -> bool {
 		match self {
-			Self::Num(numty, ..) => (numty.size(), Some(numty.size())),
-
-			Self::Str(utf8, len) => {
-				if !utf8 && let Some(exact) = len.exact() {
-					(exact as usize, Some(exact as usize))
-				} else {
-					let (len_numty, ..) = len.numty();
-
-					(
-						len.min().map(|min| min as usize).unwrap_or(0) + len_numty.size(),
-						len.max().map(|max| max as usize + len_numty.size()),
-					)
-				}
-			}
-
-			Self::Buf(len) => {
-				if let Some(exact) = len.exact() {
-					(exact as usize, Some(exact as usize))
-				} else {
-					let (len_numty, ..) = len.numty();
-
-					(
-						len.min().map(|min| min as usize).unwrap_or(0) + len_numty.size(),
-						len.max().map(|max| max as usize + len_numty.size()),
-					)
-				}
-			}
-
-			Self::Arr(ty, len) => {
-				let (ty_min, ty_max) = ty.size(recursed);
-				let len_min = len.min().map(|min| min as usize).unwrap_or(0);
-				let (len_numty, ..) = len.numty();
-
-				if let Some(exact) = len.exact() {
-					(ty_min * (exact as usize), ty_max.map(|max| max * exact as usize))
-				} else {
-					(
-						ty_min * len_min + len_numty.size(),
-						ty_max
-							.zip(len.max())
-							.map(|(ty_max, max)| ty_max * max as usize + len_numty.size()),
-					)
-				}
-			}
-
-			Self::Map(k, v) => {
-				if let Some((variants_numty, variants)) = k.variants() {
-					(
-						variants_numty.size(),
-						v.size(recursed).1.map(|size| variants * size + variants_numty.size()),
-					)
-				} else {
-					(2, None)
-				}
-			}
-
-			Self::Set(k) => {
-				if let Some((variants_numty, variants)) = k.variants() {
-					(
-						variants_numty.size(),
-						k.size(recursed).1.map(|size| variants * size + variants_numty.size()),
-					)
-				} else {
-					(2, None)
-				}
-			}
-
-			Self::Opt(ty) => {
-				let (_, ty_max) = ty.size(recursed);
-
-				(1, ty_max.map(|ty_max| ty_max + 1))
-			}
-
-			Self::Ref(tydecl) => {
-				let name = tydecl.to_string();
-				if recursed.contains(&name) {
-					// 0 is returned here because all valid recursive types are
-					// bounded and all bounded types have their own min size
-					(0, None)
-				} else {
-					recursed.insert(name.clone());
-
-					tydecl.ty.borrow().size(recursed)
-				}
-			}
-
-			Self::Enum(enum_ty) => enum_ty.size(recursed),
-			Self::Struct(struct_ty) => struct_ty.size(recursed),
-			Self::Or(or_tys, optional) => {
-				let mut min = 0;
-				let mut max = Some(0usize);
-
-				for ty in or_tys {
-					let (ty_min, ty_max) = ty.size(recursed);
-
-					if ty_min < min {
-						min = ty_min;
-					}
-
-					if let Some(ty_max) = ty_max {
-						if let Some(current_max) = max {
-							if ty_max > current_max {
-								max = Some(ty_max);
-							}
-						}
-					} else {
-						max = None;
-					}
-				}
-
-				let discriminant_numty = NumTy::from_f64(
-					0.0,
-					(or_tys
-						.iter()
-						.map(|ty| match ty.primitive_ty() {
-							PrimitiveTy::Enum(Enum::Unit(variants)) => variants.len(),
-							PrimitiveTy::Enum(Enum::Tagged { variants, .. }) => variants.len(),
-							_ => 1,
-						})
-						.sum::<usize>() + *optional as usize) as f64,
-				);
-
-				(
-					min + discriminant_numty.size(),
-					max.map(|max| max + discriminant_numty.size()),
-				)
-			}
-
-			Self::Instance(_) => (4, Some(4)),
-
-			Self::BrickColor => (2, Some(2)),
-			Self::DateTimeMillis => (8, Some(8)),
-			Self::DateTime => (8, Some(8)),
-			Self::Boolean => (1, Some(1)),
-			Self::Color3 => (12, Some(12)),
-			Self::Vector2 => (8, Some(8)),
-			Self::Vector3 => (12, Some(12)),
-			Self::Vector(x_ty, y_ty, z_ty) => {
-				let x_size = match **x_ty {
-					Ty::Num(numty, _) => numty.size(),
-					_ => 0,
-				};
-				let y_size = match **y_ty {
-					Ty::Num(numty, _) => numty.size(),
-					_ => 0,
-				};
-				let z_size = if let Some(z_ty) = z_ty {
-					match **z_ty {
-						Ty::Num(numty, _) => numty.size(),
-						_ => 0,
-					}
-				} else {
-					0
-				};
-
-				let total = x_size + y_size + z_size;
-				(total, Some(total))
-			}
-			Self::AlignedCFrame => (13, Some(13)),
-			Self::CFrame => (24, Some(24)),
-			Self::Unknown => (0, None),
+			Ty::Struct(data) => data.fields.iter().all(|(_, ty)| ty.size_known()),
+			Ty::Enum(Enum::Tagged { variants, .. }) => variants
+				.iter()
+				.flat_map(|(_, data)| data.fields.iter())
+				.all(|(_, ty)| ty.size_known()),
+			Ty::Or(tys, _) => tys.iter().all(|ty| ty.size_known()),
+			Ty::Opt(ty) => ty.size_known(),
+			// recursive
+			Ty::Ref(..) => false,
+			Ty::Map(..) | Ty::Set(..) => false,
+			_ => true,
 		}
 	}
 
@@ -553,71 +396,9 @@ pub enum Enum<'src> {
 	},
 }
 
-impl Enum<'_> {
-	pub fn size(&self, recursed: &mut HashSet<String>) -> (usize, Option<usize>) {
-		match self {
-			Self::Unit(enumerators) => {
-				let numty = NumTy::from_f64(0.0, enumerators.len() as f64 - 1.0);
-
-				(numty.size(), Some(numty.size()))
-			}
-
-			Self::Tagged { variants, .. } => {
-				let mut min = 0;
-				let mut max = Some(0);
-
-				for (_, ty) in variants.iter() {
-					let (ty_min, ty_max) = ty.size(recursed);
-
-					if ty_min < min {
-						min = ty_min;
-					}
-
-					if let Some(ty_max) = ty_max {
-						if let Some(current_max) = max {
-							if ty_max > current_max {
-								max = Some(ty_max);
-							}
-						}
-					} else {
-						max = None;
-					}
-				}
-
-				(min, max)
-			}
-		}
-	}
-}
-
 #[derive(Debug, Clone)]
 pub struct Struct<'src> {
 	pub fields: Vec<(&'src str, Ty<'src>)>,
-}
-
-impl Struct<'_> {
-	pub fn size(&self, recursed: &mut HashSet<String>) -> (usize, Option<usize>) {
-		let mut min = 0;
-		let mut max = Some(0);
-
-		for (_, ty) in self.fields.iter() {
-			let (ty_min, ty_max) = ty.size(recursed);
-
-			if ty_min < min {
-				min = ty_min;
-			}
-
-			if let Some(ty_max) = ty_max {
-				if let Some(current_max) = max {
-					max = Some(ty_max + current_max);
-				}
-			} else {
-				max = None;
-			}
-		}
-
-		(min, max)
-	}
 }
 
 #[derive(Debug, Clone, Copy, Default)]

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -1,8 +1,7 @@
 use crate::{
 	config::{Enum, NumTy, PrimitiveTy, Struct, Ty, TypeScriptEnumType},
 	irgen::{
-		BitpackMask, DynamicScope, OutputBuffer, Scopes, VariantStorageKind, readf32, readf64, readnumty, readstring,
-		readu8, readu16, readvector, readvector3,
+		AllocScope, BitpackMask, DynamicScope, GenNumExt, OutputBuffer, Scopes, VariantStorageKind, alloc, readstring,
 	},
 };
 use std::collections::HashMap;
@@ -47,6 +46,24 @@ impl Gen for Des<'_> {
 }
 
 impl Des<'_> {
+	fn new_alloc_scope(&mut self) {
+		let scope_buf = OutputBuffer::new();
+		self.buf.push(scope_buf.clone());
+		let cursor_name = self.add_occurrence("cursor").0;
+		self.scopes.alloc.push(AllocScope::new(scope_buf, cursor_name));
+	}
+
+	fn end_alloc_scope(&mut self) {
+		self.end_alloc_scope_complex(|e| e, 0);
+	}
+
+	fn end_alloc_scope_complex(&mut self, cb: impl FnOnce(Expr) -> Expr, offset: usize) {
+		let scope = self.scopes.alloc.pop().unwrap();
+		scope.offset_by(offset);
+		let size_expr = Expr::Num(scope.size as f64);
+		scope.buf.push_local(scope.cursor_var, Some(alloc(cb(size_expr))));
+	}
+
 	fn new_dyn_scope(&mut self) {
 		let scope_buf = OutputBuffer::new();
 		self.buf.push(scope_buf.clone());
@@ -90,7 +107,8 @@ impl Des<'_> {
 		match storage {
 			VariantStorageKind::Full(numty, amount) => {
 				let (variant_i, variant_expr) = self.add_occurrence("variant");
-				self.buf.push_local(variant_i, Some(readnumty(numty)));
+				let expr = self.readnumty(numty);
+				self.buf.push_local(variant_i, Some(expr));
 				for i in 0..amount {
 					let cond = variant_expr.clone().eq((i as f64).into());
 
@@ -228,7 +246,8 @@ impl Des<'_> {
 
 		match ty {
 			Ty::Num(numty, range) => {
-				self.buf.push_assign(into, readnumty(*numty));
+				let expr = self.readnumty(*numty);
+				self.buf.push_assign(into, expr);
 
 				if self.checks {
 					self.buf.push_range_check(into_expr, *range);
@@ -242,7 +261,7 @@ impl Des<'_> {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty();
 
-					let mut offset_len_expr = readnumty(len_numty);
+					let mut offset_len_expr = self.readnumty(len_numty);
 					if len_offset != 0.0 {
 						offset_len_expr = offset_len_expr.add(Expr::Num(len_offset))
 					}
@@ -268,7 +287,7 @@ impl Des<'_> {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty();
 
-					let mut offset_len_expr = readnumty(len_numty);
+					let mut offset_len_expr = self.readnumty(len_numty);
 					if len_offset != 0.0 {
 						offset_len_expr = offset_len_expr.add(Expr::Num(len_offset))
 					}
@@ -302,7 +321,7 @@ impl Des<'_> {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty();
 
-					let mut offset_len_expr = readnumty(len_numty);
+					let mut offset_len_expr = self.readnumty(len_numty);
 					if len_offset != 0.0 {
 						offset_len_expr = offset_len_expr.add(Expr::Num(len_offset))
 					}
@@ -356,10 +375,12 @@ impl Des<'_> {
 				let empty_expr = self.check_bitfield(empty_bits, empty_var);
 				self.buf.push(Stmt::If(empty_expr.not()));
 
+				let offset_len_expr = self.readnumty(length_numty).add(1.0.into());
+
 				self.buf.push(Stmt::NumFor {
 					var: "_".into(),
 					from: 1.0.into(),
-					to: readnumty(length_numty).add(1.0.into()),
+					to: offset_len_expr,
 				});
 
 				self.new_dyn_scope();
@@ -391,10 +412,12 @@ impl Des<'_> {
 				let empty_expr = self.check_bitfield(empty_bits, empty_var);
 				self.buf.push(Stmt::If(empty_expr.not()));
 
+				let offset_len_expr = self.readnumty(length_numty).add(1.0.into());
+
 				self.buf.push(Stmt::NumFor {
 					var: "_".into(),
 					from: 1.0.into(),
-					to: readnumty(length_numty).add(1.0.into()),
+					to: offset_len_expr,
 				});
 
 				self.new_dyn_scope();
@@ -510,28 +533,38 @@ impl Des<'_> {
 				);
 			}
 
-			Ty::BrickColor => self.buf.push_assign(
-				into,
-				Expr::Call(Box::new(Var::from("BrickColor").nindex("new")), None, vec![readu16()]),
-			),
+			Ty::BrickColor => {
+				let expr = self.readu16();
 
-			Ty::DateTimeMillis => self.buf.push_assign(
-				into,
-				Expr::Call(
-					Box::new(Var::from("DateTime").nindex("fromUnixTimestampMillis")),
-					None,
-					vec![readf64()],
-				),
-			),
+				self.buf.push_assign(
+					into,
+					Expr::Call(Box::new(Var::from("BrickColor").nindex("new")), None, vec![expr]),
+				)
+			}
 
-			Ty::DateTime => self.buf.push_assign(
-				into,
-				Expr::Call(
-					Box::new(Var::from("DateTime").nindex("fromUnixTimestamp")),
-					None,
-					vec![readf64()],
-				),
-			),
+			Ty::DateTimeMillis => {
+				let expr = self.readf64();
+				self.buf.push_assign(
+					into,
+					Expr::Call(
+						Box::new(Var::from("DateTime").nindex("fromUnixTimestampMillis")),
+						None,
+						vec![expr],
+					),
+				)
+			}
+
+			Ty::DateTime => {
+				let expr = self.readf64();
+				self.buf.push_assign(
+					into,
+					Expr::Call(
+						Box::new(Var::from("DateTime").nindex("fromUnixTimestamp")),
+						None,
+						vec![expr],
+					),
+				)
+			}
 
 			Ty::Boolean => {
 				let (bits, var) = self.get_bitpack();
@@ -540,20 +573,32 @@ impl Des<'_> {
 				self.buf.push_assign(into, expr);
 			}
 
-			Ty::Color3 => self.buf.push_assign(
-				into,
-				Expr::Color3(Box::new(readu8()), Box::new(readu8()), Box::new(readu8())),
-			),
+			Ty::Color3 => {
+				let r = self.readu8();
+				let g = self.readu8();
+				let b = self.readu8();
 
-			Ty::Vector2 => self.buf.push_assign(
-				into,
-				Expr::Call(
-					Box::new(Var::from("Vector3").nindex("new")),
-					None,
-					vec![readf32(), readf32(), "0".into()],
-				),
-			),
-			Ty::Vector3 => self.buf.push_assign(into, readvector3()),
+				self.buf
+					.push_assign(into, Expr::Color3(Box::new(r), Box::new(g), Box::new(b)))
+			}
+
+			Ty::Vector2 => {
+				let x = self.readf32();
+				let y = self.readf32();
+
+				self.buf.push_assign(
+					into,
+					Expr::Call(
+						Box::new(Var::from("Vector3").nindex("new")),
+						None,
+						vec![x, y, "0".into()],
+					),
+				)
+			}
+			Ty::Vector3 => {
+				let expr = self.readvector3();
+				self.buf.push_assign(into, expr)
+			}
 			Ty::Vector(x_ty, y_ty, z_ty) => {
 				let x_numty = match **x_ty {
 					Ty::Num(numty, range) => {
@@ -590,17 +635,19 @@ impl Des<'_> {
 					None
 				};
 
-				self.buf.push_assign(into, readvector(x_numty, y_numty, z_numty));
+				let expr = self.readvector(x_numty, y_numty, z_numty);
+				self.buf.push_assign(into, expr);
 			}
 
 			Ty::AlignedCFrame => {
 				let (axis_alignment_name, axis_alignment_expr) = self.add_occurrence("axis_alignment");
-
-				self.buf.push_local(axis_alignment_name, Some(readu8()));
+				let align_expr = self.readu8();
+				self.buf.push_local(axis_alignment_name, Some(align_expr));
 
 				let (pos_name, pos_expr) = self.add_occurrence("pos");
 
-				self.buf.push_local(pos_name.clone(), Some(readvector3()));
+				let pos_vec = self.readvector3();
+				self.buf.push_local(pos_name.clone(), Some(pos_vec));
 
 				self.buf.push_assign(
 					into,
@@ -620,9 +667,11 @@ impl Des<'_> {
 			}
 			Ty::CFrame => {
 				let (pos_name, pos_expr) = self.add_occurrence("pos");
-				self.buf.push_local(pos_name.clone(), Some(readvector3()));
+				let pos_vec = self.readvector3();
+				self.buf.push_local(pos_name.clone(), Some(pos_vec));
 				let (axisangle_name, axisangle_expr) = self.add_occurrence("axisangle");
-				self.buf.push_local(axisangle_name.clone(), Some(readvector3()));
+				let axis_expr = self.readvector3();
+				self.buf.push_local(axisangle_name.clone(), Some(axis_expr));
 				let (angle_name, angle_expr) = self.add_occurrence("angle");
 				self.buf.push_local(
 					angle_name,

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -1,7 +1,7 @@
 use crate::{
 	config::{Enum, NumTy, PrimitiveTy, Struct, Ty, TypeScriptEnumType},
 	irgen::{
-		AllocScope, BitpackMask, DynamicScope, GenNumExt, OutputBuffer, Scopes, VariantStorageKind, alloc, readstring,
+		AllocScope, BitpackMask, DynamicScope, GenNumExt, OutputBuffer, Scopes, VariantStorageKind, read, readstring,
 	},
 };
 use std::collections::HashMap;
@@ -25,6 +25,7 @@ impl Gen for Des<'_> {
 	where
 		I: Iterator<Item = &'a Ty<'src>>,
 	{
+		self.new_alloc_scope();
 		self.new_dyn_scope();
 
 		for (ty, name) in types.zip(names) {
@@ -32,6 +33,7 @@ impl Gen for Des<'_> {
 		}
 
 		self.end_dyn_scope();
+		self.end_alloc_scope();
 
 		self.buf.output()
 	}
@@ -61,7 +63,7 @@ impl Des<'_> {
 		let scope = self.scopes.alloc.pop().unwrap();
 		scope.offset_by(offset);
 		let size_expr = Expr::Num(scope.size as f64);
-		scope.buf.push_local(scope.cursor_var, Some(alloc(cb(size_expr))));
+		scope.buf.push_local(scope.cursor_var, Some(read(cb(size_expr))));
 	}
 
 	fn new_dyn_scope(&mut self) {
@@ -78,22 +80,10 @@ impl Des<'_> {
 
 		for (shift, name) in scope.bitpack_budget {
 			let numty = NumTy::from_f64(0.0, ((1u64 << (shift + 1)) - 1) as f64);
+			let value = self.readnumty_raw(numty, true);
 
-			scope.buf.push(Stmt::Local(
-				name.clone(),
-				Some(Expr::Call(
-					Var::NameIndex(Var::Name("buffer".into()).into(), format!("read{numty}")).into(),
-					None,
-					vec![
-						Expr::Var(Var::Name("incoming_buff".into()).into()),
-						Expr::Call(
-							Var::Name("read".into()).into(),
-							None,
-							vec![Expr::Num(numty.size() as f64)],
-						),
-					],
-				)),
-			));
+			scope.buf.push(move || Stmt::Local(name.clone(), Some(value())));
+			self.scopes.alloc().offset_by(numty.size());
 		}
 	}
 
@@ -108,7 +98,7 @@ impl Des<'_> {
 			VariantStorageKind::Full(numty, amount) => {
 				let (variant_i, variant_expr) = self.add_occurrence("variant");
 				let expr = self.readnumty(numty);
-				self.buf.push_local(variant_i, Some(expr));
+				self.buf.push(move || Stmt::Local(variant_i, Some(expr())));
 				for i in 0..amount {
 					let cond = variant_expr.clone().eq((i as f64).into());
 
@@ -203,7 +193,9 @@ impl Des<'_> {
 									Expr::StrOrBool(variant.to_string()),
 								)])),
 							);
+							this.new_alloc_scope();
 							this.push_struct(&data, into.clone());
+							this.end_alloc_scope();
 						}));
 					}
 				}
@@ -215,7 +207,9 @@ impl Des<'_> {
 				PrimitiveTy::None(..) => unreachable!(),
 				_ => {
 					ty_functions.push(Box::new(|this| {
+						this.new_alloc_scope();
 						this.push_ty(ty, into.clone());
+						this.end_alloc_scope();
 					}));
 				}
 			};
@@ -247,7 +241,7 @@ impl Des<'_> {
 		match ty {
 			Ty::Num(numty, range) => {
 				let expr = self.readnumty(*numty);
-				self.buf.push_assign(into, expr);
+				self.buf.push(move || Stmt::Assign(into, expr()));
 
 				if self.checks {
 					self.buf.push_range_check(into_expr, *range);
@@ -261,12 +255,16 @@ impl Des<'_> {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty();
 
-					let mut offset_len_expr = self.readnumty(len_numty);
-					if len_offset != 0.0 {
-						offset_len_expr = offset_len_expr.add(Expr::Num(len_offset))
-					}
+					let offset_len_expr = self.readnumty(len_numty);
 
-					self.buf.push_local(len_name.clone(), Some(offset_len_expr));
+					self.buf.push(move || {
+						let mut offset_len_expr = offset_len_expr();
+						if len_offset != 0.0 {
+							offset_len_expr = offset_len_expr.add(Expr::Num(len_offset))
+						}
+
+						Stmt::Local(len_name.clone(), Some(offset_len_expr))
+					});
 
 					if self.checks {
 						self.buf.push_range_check(len_expr.clone(), *range);
@@ -287,12 +285,16 @@ impl Des<'_> {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty();
 
-					let mut offset_len_expr = self.readnumty(len_numty);
-					if len_offset != 0.0 {
-						offset_len_expr = offset_len_expr.add(Expr::Num(len_offset))
-					}
+					let offset_len_expr = self.readnumty(len_numty);
 
-					self.buf.push_local(len_name.clone(), Some(offset_len_expr));
+					self.buf.push(move || {
+						let mut offset_len_expr = offset_len_expr();
+						if len_offset != 0.0 {
+							offset_len_expr = offset_len_expr.add(Expr::Num(len_offset))
+						}
+
+						Stmt::Local(len_name.clone(), Some(offset_len_expr))
+					});
 
 					if self.checks {
 						self.buf.push_range_check(len_expr.clone(), *range);
@@ -321,12 +323,16 @@ impl Des<'_> {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty();
 
-					let mut offset_len_expr = self.readnumty(len_numty);
-					if len_offset != 0.0 {
-						offset_len_expr = offset_len_expr.add(Expr::Num(len_offset))
-					}
+					let offset_len_expr = self.readnumty(len_numty);
 
-					self.buf.push_local(len_name.clone(), Some(offset_len_expr));
+					self.buf.push(move || {
+						let mut offset_len_expr = offset_len_expr();
+						if len_offset != 0.0 {
+							offset_len_expr = offset_len_expr.add(Expr::Num(len_offset))
+						}
+
+						Stmt::Local(len_name.clone(), Some(offset_len_expr))
+					});
 
 					if self.checks {
 						self.buf.push_range_check(len_expr.clone(), *range);
@@ -340,6 +346,8 @@ impl Des<'_> {
 							vec![len_expr.clone()],
 						),
 					);
+
+					self.new_alloc_scope();
 
 					self.buf.push(Stmt::NumFor {
 						var: var_name.clone(),
@@ -363,6 +371,10 @@ impl Des<'_> {
 					self.end_dyn_scope();
 
 					self.buf.push(Stmt::End);
+
+					let scope = self.scopes.alloc();
+					scope.offset_expr(var_expr.clone().sub(1.0.into()).mul((scope.size as f64).into()));
+					self.end_alloc_scope_complex(|expr| expr.mul(len_expr), 0);
 				}
 			}
 
@@ -375,14 +387,15 @@ impl Des<'_> {
 				let empty_expr = self.check_bitfield(empty_bits, empty_var);
 				self.buf.push(Stmt::If(empty_expr.not()));
 
-				let offset_len_expr = self.readnumty(length_numty).add(1.0.into());
+				let offset_len_expr = self.readnumty(length_numty);
 
-				self.buf.push(Stmt::NumFor {
+				self.buf.push(move || Stmt::NumFor {
 					var: "_".into(),
 					from: 1.0.into(),
-					to: offset_len_expr,
+					to: offset_len_expr().add(1.0.into()),
 				});
 
+				self.new_alloc_scope();
 				self.new_dyn_scope();
 
 				let (key_name, key_expr) = self.add_occurrence("key");
@@ -397,6 +410,7 @@ impl Des<'_> {
 					.push_assign(into.clone().eindex(key_expr.clone()), val_expr.clone());
 
 				self.end_dyn_scope();
+				self.end_alloc_scope();
 
 				self.buf.push(Stmt::End);
 
@@ -412,14 +426,15 @@ impl Des<'_> {
 				let empty_expr = self.check_bitfield(empty_bits, empty_var);
 				self.buf.push(Stmt::If(empty_expr.not()));
 
-				let offset_len_expr = self.readnumty(length_numty).add(1.0.into());
+				let offset_len_expr = self.readnumty(length_numty);
 
-				self.buf.push(Stmt::NumFor {
+				self.buf.push(move || Stmt::NumFor {
 					var: "_".into(),
 					from: 1.0.into(),
-					to: offset_len_expr,
+					to: offset_len_expr().add(1.0.into()),
 				});
 
+				self.new_alloc_scope();
 				self.new_dyn_scope();
 
 				let (key_name, key_expr) = self.add_occurrence("key");
@@ -430,6 +445,7 @@ impl Des<'_> {
 				self.buf.push_assign(into.clone().eindex(key_expr.clone()), Expr::True);
 
 				self.end_dyn_scope();
+				self.end_alloc_scope();
 
 				self.buf.push(Stmt::End);
 
@@ -445,6 +461,8 @@ impl Des<'_> {
 				let expr = self.check_bitfield(bits, var);
 
 				self.buf.push(Stmt::If(expr));
+
+				self.new_alloc_scope();
 
 				if let Ty::Instance(class) = **ty {
 					self.buf
@@ -469,6 +487,8 @@ impl Des<'_> {
 				} else {
 					self.push_ty(ty, into.clone())
 				}
+
+				self.end_alloc_scope();
 
 				self.buf.push(Stmt::Else);
 				self.buf.push_assign(into, Expr::Nil);
@@ -536,34 +556,40 @@ impl Des<'_> {
 			Ty::BrickColor => {
 				let expr = self.readu16();
 
-				self.buf.push_assign(
-					into,
-					Expr::Call(Box::new(Var::from("BrickColor").nindex("new")), None, vec![expr]),
-				)
+				self.buf.push(move || {
+					Stmt::Assign(
+						into,
+						Expr::Call(Box::new(Var::from("BrickColor").nindex("new")), None, vec![expr()]),
+					)
+				})
 			}
 
 			Ty::DateTimeMillis => {
 				let expr = self.readf64();
-				self.buf.push_assign(
-					into,
-					Expr::Call(
-						Box::new(Var::from("DateTime").nindex("fromUnixTimestampMillis")),
-						None,
-						vec![expr],
-					),
-				)
+				self.buf.push(move || {
+					Stmt::Assign(
+						into,
+						Expr::Call(
+							Box::new(Var::from("DateTime").nindex("fromUnixTimestampMillis")),
+							None,
+							vec![expr()],
+						),
+					)
+				})
 			}
 
 			Ty::DateTime => {
 				let expr = self.readf64();
-				self.buf.push_assign(
-					into,
-					Expr::Call(
-						Box::new(Var::from("DateTime").nindex("fromUnixTimestamp")),
-						None,
-						vec![expr],
-					),
-				)
+				self.buf.push(move || {
+					Stmt::Assign(
+						into,
+						Expr::Call(
+							Box::new(Var::from("DateTime").nindex("fromUnixTimestamp")),
+							None,
+							vec![expr()],
+						),
+					)
+				})
 			}
 
 			Ty::Boolean => {
@@ -579,25 +605,27 @@ impl Des<'_> {
 				let b = self.readu8();
 
 				self.buf
-					.push_assign(into, Expr::Color3(Box::new(r), Box::new(g), Box::new(b)))
+					.push(move || Stmt::Assign(into, Expr::Color3(Box::new(r()), Box::new(g()), Box::new(b()))))
 			}
 
 			Ty::Vector2 => {
 				let x = self.readf32();
 				let y = self.readf32();
 
-				self.buf.push_assign(
-					into,
-					Expr::Call(
-						Box::new(Var::from("Vector3").nindex("new")),
-						None,
-						vec![x, y, "0".into()],
-					),
-				)
+				self.buf.push(move || {
+					Stmt::Assign(
+						into,
+						Expr::Call(
+							Box::new(Var::from("Vector3").nindex("new")),
+							None,
+							vec![x(), y(), "0".into()],
+						),
+					)
+				})
 			}
 			Ty::Vector3 => {
 				let expr = self.readvector3();
-				self.buf.push_assign(into, expr)
+				self.buf.push(move || Stmt::Assign(into, expr()))
 			}
 			Ty::Vector(x_ty, y_ty, z_ty) => {
 				let x_numty = match **x_ty {
@@ -636,18 +664,18 @@ impl Des<'_> {
 				};
 
 				let expr = self.readvector(x_numty, y_numty, z_numty);
-				self.buf.push_assign(into, expr);
+				self.buf.push(move || Stmt::Assign(into, expr()));
 			}
 
 			Ty::AlignedCFrame => {
 				let (axis_alignment_name, axis_alignment_expr) = self.add_occurrence("axis_alignment");
 				let align_expr = self.readu8();
-				self.buf.push_local(axis_alignment_name, Some(align_expr));
-
+				self.buf
+					.push(move || Stmt::Local(axis_alignment_name, Some(align_expr())));
 				let (pos_name, pos_expr) = self.add_occurrence("pos");
 
 				let pos_vec = self.readvector3();
-				self.buf.push_local(pos_name.clone(), Some(pos_vec));
+				self.buf.push(move || Stmt::Local(pos_name.clone(), Some(pos_vec())));
 
 				self.buf.push_assign(
 					into,
@@ -668,10 +696,11 @@ impl Des<'_> {
 			Ty::CFrame => {
 				let (pos_name, pos_expr) = self.add_occurrence("pos");
 				let pos_vec = self.readvector3();
-				self.buf.push_local(pos_name.clone(), Some(pos_vec));
+				self.buf.push(move || Stmt::Local(pos_name.clone(), Some(pos_vec())));
 				let (axisangle_name, axisangle_expr) = self.add_occurrence("axisangle");
 				let axis_expr = self.readvector3();
-				self.buf.push_local(axisangle_name.clone(), Some(axis_expr));
+				let axis_name = axisangle_name.clone();
+				self.buf.push(move || Stmt::Local(axis_name, Some(axis_expr())));
 				let (angle_name, angle_expr) = self.add_occurrence("angle");
 				self.buf.push_local(
 					angle_name,

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -1,6 +1,9 @@
 use crate::{
 	config::{Enum, NumTy, PrimitiveTy, Struct, Ty, TypeScriptEnumType},
-	irgen::{BitpackMask, OutputBuffer, Scope, VariantStorageKind},
+	irgen::{
+		BitpackMask, DynamicScope, OutputBuffer, Scopes, VariantStorageKind, readf32, readf64, readnumty, readstring,
+		readu8, readu16, readvector, readvector3,
+	},
 };
 use std::collections::HashMap;
 
@@ -10,26 +13,26 @@ struct Des<'src> {
 	checks: bool,
 	buf: OutputBuffer,
 	var_occurrences: &'src mut HashMap<String, usize>,
-	scopes: Vec<Scope>,
+	scopes: Scopes,
 	typescript_enum_type: TypeScriptEnumType,
 }
 
 impl Gen for Des<'_> {
-	fn push_stmt(&mut self, stmt: Stmt) {
-		self.buf.push(stmt);
+	fn buf(&self) -> &OutputBuffer {
+		&self.buf
 	}
 
 	fn generate<'a, 'src: 'a, I>(mut self, names: &[String], types: I) -> Vec<Stmt>
 	where
 		I: Iterator<Item = &'a Ty<'src>>,
 	{
-		self.new_scope();
+		self.new_dyn_scope();
 
 		for (ty, name) in types.zip(names) {
 			self.push_ty(ty, Var::Name(name.to_string()));
 		}
 
-		self.end_scope();
+		self.end_dyn_scope();
 
 		self.buf.output()
 	}
@@ -38,21 +41,23 @@ impl Gen for Des<'_> {
 		self.var_occurrences
 	}
 
-	fn new_scope(&mut self) {
+	fn scopes(&mut self) -> &mut Scopes {
+		&mut self.scopes
+	}
+}
+
+impl Des<'_> {
+	fn new_dyn_scope(&mut self) {
 		let scope_buf = OutputBuffer::new();
 		self.buf.push(scope_buf.clone());
-		self.scopes.push(Scope {
+		self.scopes.dynamic.push(DynamicScope {
 			bitpack_budget: vec![],
 			buf: scope_buf,
 		});
 	}
 
-	fn current_scope(&mut self) -> &mut Scope {
-		self.scopes.last_mut().unwrap()
-	}
-
-	fn end_scope(&mut self) {
-		let scope = self.scopes.pop().unwrap();
+	fn end_dyn_scope(&mut self) {
+		let scope = self.scopes.dynamic.pop().unwrap();
 
 		for (shift, name) in scope.bitpack_budget {
 			let numty = NumTy::from_f64(0.0, ((1u64 << (shift + 1)) - 1) as f64);
@@ -74,9 +79,7 @@ impl Gen for Des<'_> {
 			));
 		}
 	}
-}
 
-impl Des<'_> {
 	fn push_struct(&mut self, struct_ty: &Struct, into: Var) {
 		for (name, ty) in struct_ty.fields.iter() {
 			self.push_ty(ty, into.clone().eindex(Expr::Str((*name).into())))
@@ -87,31 +90,31 @@ impl Des<'_> {
 		match storage {
 			VariantStorageKind::Full(numty, amount) => {
 				let (variant_i, variant_expr) = self.add_occurrence("variant");
-				self.push_local(variant_i, Some(self.readnumty(numty)));
+				self.buf.push_local(variant_i, Some(readnumty(numty)));
 				for i in 0..amount {
 					let cond = variant_expr.clone().eq((i as f64).into());
 
-					self.push_stmt(if i == 0 { Stmt::If(cond) } else { Stmt::ElseIf(cond) });
+					self.buf.push(if i == 0 { Stmt::If(cond) } else { Stmt::ElseIf(cond) });
 					cb(self, i);
 				}
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::End);
 			}
 			VariantStorageKind::Bitpack(variants) => {
 				for (i, (bits, var)) in variants.into_iter().enumerate() {
 					let cond = self.check_bitfield(bits, var);
 
-					self.push_stmt(if i == 0 { Stmt::If(cond) } else { Stmt::ElseIf(cond) });
+					self.buf.push(if i == 0 { Stmt::If(cond) } else { Stmt::ElseIf(cond) });
 					cb(self, i);
 				}
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::End);
 			}
 			VariantStorageKind::Bit((bits, var)) => {
 				let cond = self.check_bitfield(bits, var);
-				self.push_stmt(Stmt::If(cond));
+				self.buf.push(Stmt::If(cond));
 				cb(self, 1);
-				self.push_stmt(Stmt::Else);
+				self.buf.push(Stmt::Else);
 				cb(self, 0);
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::End);
 			}
 			VariantStorageKind::None => {
 				cb(self, 0);
@@ -130,7 +133,7 @@ impl Des<'_> {
 						_ => Expr::StrOrBool(enumerators[i].to_string()),
 					};
 
-					this.push_assign(into.clone(), condition);
+					this.buf.push_assign(into.clone(), condition);
 				});
 			}
 
@@ -139,7 +142,7 @@ impl Des<'_> {
 
 				self.read_variant_storage(storage, |this, i| {
 					let (name, struct_ty) = &variants[i];
-					this.push_assign(
+					this.buf.push_assign(
 						into.clone(),
 						Expr::Table(Box::new(vec![(
 							Expr::Str(tag.to_string()),
@@ -167,7 +170,7 @@ impl Des<'_> {
 								_ => Expr::StrOrBool(variant.to_string()),
 							};
 
-							this.push_assign(into.clone(), condition);
+							this.buf.push_assign(into.clone(), condition);
 						}));
 					}
 				}
@@ -175,7 +178,7 @@ impl Des<'_> {
 					for (variant, data) in variants {
 						let into = into.clone();
 						ty_functions.push(Box::new(move |this| {
-							this.push_assign(
+							this.buf.push_assign(
 								into.clone(),
 								Expr::Table(Box::new(vec![(
 									Expr::Str(tag.to_string()),
@@ -202,7 +205,7 @@ impl Des<'_> {
 
 		if optional {
 			ty_functions.push(Box::new(|this| {
-				this.push_assign(into.clone(), Expr::Nil);
+				this.buf.push_assign(into.clone(), Expr::Nil);
 			}));
 		}
 
@@ -225,64 +228,64 @@ impl Des<'_> {
 
 		match ty {
 			Ty::Num(numty, range) => {
-				self.push_assign(into, self.readnumty(*numty));
+				self.buf.push_assign(into, readnumty(*numty));
 
 				if self.checks {
-					self.push_range_check(into_expr, *range);
+					self.buf.push_range_check(into_expr, *range);
 				}
 			}
 
 			Ty::Str(utf8, range) => {
 				if !utf8 && let Some(len) = range.exact() {
-					self.push_assign(into, self.readstring(len.into()));
+					self.buf.push_assign(into, readstring(len.into()));
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty();
 
-					let mut offset_len_expr = self.readnumty(len_numty);
+					let mut offset_len_expr = readnumty(len_numty);
 					if len_offset != 0.0 {
 						offset_len_expr = offset_len_expr.add(Expr::Num(len_offset))
 					}
 
-					self.push_local(len_name.clone(), Some(offset_len_expr));
+					self.buf.push_local(len_name.clone(), Some(offset_len_expr));
 
 					if self.checks {
-						self.push_range_check(len_expr.clone(), *range);
+						self.buf.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_assign(into.clone(), self.readstring(len_expr.clone()));
+					self.buf.push_assign(into.clone(), readstring(len_expr.clone()));
 
 					if *utf8 {
-						self.push_utf8_check(Expr::Var(into.into()));
+						self.buf.push_utf8_check(Expr::Var(into.into()));
 					}
 				}
 			}
 
 			Ty::Buf(range) => {
 				if let Some(len) = range.exact() {
-					self.push_read_copy(into, len.into());
+					self.buf.push_read_copy(into, len.into());
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty();
 
-					let mut offset_len_expr = self.readnumty(len_numty);
+					let mut offset_len_expr = readnumty(len_numty);
 					if len_offset != 0.0 {
 						offset_len_expr = offset_len_expr.add(Expr::Num(len_offset))
 					}
 
-					self.push_local(len_name.clone(), Some(offset_len_expr));
+					self.buf.push_local(len_name.clone(), Some(offset_len_expr));
 
 					if self.checks {
-						self.push_range_check(len_expr.clone(), *range);
+						self.buf.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_read_copy(into, len_expr.clone())
+					self.buf.push_read_copy(into, len_expr.clone())
 				}
 			}
 
 			Ty::Arr(ty, range) => {
 				if let Some(len) = range.exact() {
-					self.push_assign(
+					self.buf.push_assign(
 						into.clone(),
 						Expr::Call(
 							Var::NameIndex(Var::Name("table".into()).into(), "create".into()).into(),
@@ -299,18 +302,18 @@ impl Des<'_> {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty();
 
-					let mut offset_len_expr = self.readnumty(len_numty);
+					let mut offset_len_expr = readnumty(len_numty);
 					if len_offset != 0.0 {
 						offset_len_expr = offset_len_expr.add(Expr::Num(len_offset))
 					}
 
-					self.push_local(len_name.clone(), Some(offset_len_expr));
+					self.buf.push_local(len_name.clone(), Some(offset_len_expr));
 
 					if self.checks {
-						self.push_range_check(len_expr.clone(), *range);
+						self.buf.push_range_check(len_expr.clone(), *range);
 					}
 
-					self.push_assign(
+					self.buf.push_assign(
 						into.clone(),
 						Expr::Call(
 							Var::NameIndex(Var::Name("table".into()).into(), "create".into()).into(),
@@ -319,28 +322,28 @@ impl Des<'_> {
 						),
 					);
 
-					self.push_stmt(Stmt::NumFor {
+					self.buf.push(Stmt::NumFor {
 						var: var_name.clone(),
 						from: 1.0.into(),
 						to: len_expr.clone(),
 					});
 
-					self.new_scope();
+					self.new_dyn_scope();
 
 					let (inner_var_name, _) = self.add_occurrence("val");
 
-					self.push_local(inner_var_name.clone(), None);
+					self.buf.push_local(inner_var_name.clone(), None);
 
 					self.push_ty(ty, Var::Name(inner_var_name.clone()));
 
-					self.push_stmt(Stmt::Assign(
+					self.buf.push(Stmt::Assign(
 						into.clone().eindex(var_expr.clone()),
 						Var::Name(inner_var_name.clone()).into(),
 					));
 
-					self.end_scope();
+					self.end_dyn_scope();
 
-					self.push_stmt(Stmt::End);
+					self.buf.push(Stmt::End);
 				}
 			}
 
@@ -348,65 +351,66 @@ impl Des<'_> {
 				let (empty_bits, empty_var) = self.get_bitpack();
 				let length_numty = key.variants().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
-				self.push_assign(into.clone(), Expr::Table(Default::default()));
+				self.buf.push_assign(into.clone(), Expr::Table(Default::default()));
 
 				let empty_expr = self.check_bitfield(empty_bits, empty_var);
-				self.push_stmt(Stmt::If(empty_expr.not()));
+				self.buf.push(Stmt::If(empty_expr.not()));
 
-				self.push_stmt(Stmt::NumFor {
+				self.buf.push(Stmt::NumFor {
 					var: "_".into(),
 					from: 1.0.into(),
-					to: self.readnumty(length_numty).add(1.0.into()),
+					to: readnumty(length_numty).add(1.0.into()),
 				});
 
-				self.new_scope();
+				self.new_dyn_scope();
 
 				let (key_name, key_expr) = self.add_occurrence("key");
-				self.push_local(key_name.clone(), None);
+				self.buf.push_local(key_name.clone(), None);
 				let (val_name, val_expr) = self.add_occurrence("val");
-				self.push_local(val_name.clone(), None);
+				self.buf.push_local(val_name.clone(), None);
 
 				self.push_ty(key, Var::Name(key_name.clone()));
 				self.push_ty(val, Var::Name(val_name.clone()));
 
-				self.push_assign(into.clone().eindex(key_expr.clone()), val_expr.clone());
+				self.buf
+					.push_assign(into.clone().eindex(key_expr.clone()), val_expr.clone());
 
-				self.end_scope();
+				self.end_dyn_scope();
 
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::End);
 
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::End);
 			}
 
 			Ty::Set(key) => {
 				let (empty_bits, empty_var) = self.get_bitpack();
 				let length_numty = key.variants().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
-				self.push_assign(into.clone(), Expr::Table(Default::default()));
+				self.buf.push_assign(into.clone(), Expr::Table(Default::default()));
 
 				let empty_expr = self.check_bitfield(empty_bits, empty_var);
-				self.push_stmt(Stmt::If(empty_expr.not()));
+				self.buf.push(Stmt::If(empty_expr.not()));
 
-				self.push_stmt(Stmt::NumFor {
+				self.buf.push(Stmt::NumFor {
 					var: "_".into(),
 					from: 1.0.into(),
-					to: self.readnumty(length_numty).add(1.0.into()),
+					to: readnumty(length_numty).add(1.0.into()),
 				});
 
-				self.new_scope();
+				self.new_dyn_scope();
 
 				let (key_name, key_expr) = self.add_occurrence("key");
-				self.push_local(key_name.clone(), None);
+				self.buf.push_local(key_name.clone(), None);
 
 				self.push_ty(key, Var::Name(key_name.clone()));
 
-				self.push_assign(into.clone().eindex(key_expr.clone()), Expr::True);
+				self.buf.push_assign(into.clone().eindex(key_expr.clone()), Expr::True);
 
-				self.end_scope();
+				self.end_dyn_scope();
 
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::End);
 
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::End);
 			}
 
 			Ty::Opt(ty) => {
@@ -417,11 +421,12 @@ impl Des<'_> {
 				let (bits, var) = self.get_bitpack();
 				let expr = self.check_bitfield(bits, var);
 
-				self.push_stmt(Stmt::If(expr));
+				self.buf.push(Stmt::If(expr));
 
 				if let Ty::Instance(class) = **ty {
-					self.push_assign(Var::from("incoming_ipos"), Expr::from("incoming_ipos").add(1.0.into()));
-					self.push_assign(
+					self.buf
+						.push_assign(Var::from("incoming_ipos"), Expr::from("incoming_ipos").add(1.0.into()));
+					self.buf.push_assign(
 						into.clone(),
 						Var::from("incoming_inst")
 							.eindex(Var::from("incoming_ipos").into())
@@ -429,7 +434,7 @@ impl Des<'_> {
 					);
 
 					if self.checks && class.is_some() {
-						self.push_assert(
+						self.buf.push_assert(
 							into_expr.clone().eq(Expr::Nil).or(Expr::Call(
 								Box::new(into.clone()),
 								Some("IsA".into()),
@@ -442,13 +447,13 @@ impl Des<'_> {
 					self.push_ty(ty, into.clone())
 				}
 
-				self.push_stmt(Stmt::Else);
-				self.push_assign(into, Expr::Nil);
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::Else);
+				self.buf.push_assign(into, Expr::Nil);
+				self.buf.push(Stmt::End);
 			}
 
 			Ty::Ref(name, ..) => {
-				self.push_assign(
+				self.buf.push_assign(
 					into,
 					Expr::Call(
 						Box::new(Var::from("types").nindex(format!("read_{name}"))),
@@ -461,15 +466,16 @@ impl Des<'_> {
 			Ty::Enum(enum_ty) => self.push_enum(enum_ty, into),
 
 			Ty::Struct(struct_ty) => {
-				self.push_assign(into.clone(), Expr::Table(Default::default()));
+				self.buf.push_assign(into.clone(), Expr::Table(Default::default()));
 				self.push_struct(struct_ty, into)
 			}
 
 			Ty::Or(tys, _) => self.push_or(into, tys, false),
 
 			Ty::Instance(class) => {
-				self.push_assign(Var::from("incoming_ipos"), Expr::from("incoming_ipos").add(1.0.into()));
-				self.push_assign(
+				self.buf
+					.push_assign(Var::from("incoming_ipos"), Expr::from("incoming_ipos").add(1.0.into()));
+				self.buf.push_assign(
 					into.clone(),
 					Var::from("incoming_inst")
 						.eindex(Var::from("incoming_ipos").into())
@@ -478,10 +484,11 @@ impl Des<'_> {
 
 				// always assert non-optional instances as roblox
 				// will sometimes vaporize them
-				self.push_assert(into_expr.clone().neq(Expr::Nil), "received instance is nil!".into());
+				self.buf
+					.push_assert(into_expr.clone().neq(Expr::Nil), "received instance is nil!".into());
 
 				if self.checks && class.is_some() {
-					self.push_assert(
+					self.buf.push_assert(
 						Expr::Call(
 							Box::new(into),
 							Some("IsA".into()),
@@ -493,8 +500,9 @@ impl Des<'_> {
 			}
 
 			Ty::Unknown => {
-				self.push_assign(Var::from("incoming_ipos"), Expr::from("incoming_ipos").add(1.0.into()));
-				self.push_assign(
+				self.buf
+					.push_assign(Var::from("incoming_ipos"), Expr::from("incoming_ipos").add(1.0.into()));
+				self.buf.push_assign(
 					into.clone(),
 					Var::from("incoming_inst")
 						.eindex(Var::from("incoming_ipos").into())
@@ -502,30 +510,26 @@ impl Des<'_> {
 				);
 			}
 
-			Ty::BrickColor => self.push_assign(
+			Ty::BrickColor => self.buf.push_assign(
 				into,
-				Expr::Call(
-					Box::new(Var::from("BrickColor").nindex("new")),
-					None,
-					vec![self.readu16()],
-				),
+				Expr::Call(Box::new(Var::from("BrickColor").nindex("new")), None, vec![readu16()]),
 			),
 
-			Ty::DateTimeMillis => self.push_assign(
+			Ty::DateTimeMillis => self.buf.push_assign(
 				into,
 				Expr::Call(
 					Box::new(Var::from("DateTime").nindex("fromUnixTimestampMillis")),
 					None,
-					vec![self.readf64()],
+					vec![readf64()],
 				),
 			),
 
-			Ty::DateTime => self.push_assign(
+			Ty::DateTime => self.buf.push_assign(
 				into,
 				Expr::Call(
 					Box::new(Var::from("DateTime").nindex("fromUnixTimestamp")),
 					None,
-					vec![self.readf64()],
+					vec![readf64()],
 				),
 			),
 
@@ -533,32 +537,28 @@ impl Des<'_> {
 				let (bits, var) = self.get_bitpack();
 				let expr = self.check_bitfield(bits, var);
 
-				self.push_assign(into, expr);
+				self.buf.push_assign(into, expr);
 			}
 
-			Ty::Color3 => self.push_assign(
+			Ty::Color3 => self.buf.push_assign(
 				into,
-				Expr::Color3(
-					Box::new(self.readu8()),
-					Box::new(self.readu8()),
-					Box::new(self.readu8()),
-				),
+				Expr::Color3(Box::new(readu8()), Box::new(readu8()), Box::new(readu8())),
 			),
 
-			Ty::Vector2 => self.push_assign(
+			Ty::Vector2 => self.buf.push_assign(
 				into,
 				Expr::Call(
 					Box::new(Var::from("Vector3").nindex("new")),
 					None,
-					vec![self.readf32(), self.readf32(), "0".into()],
+					vec![readf32(), readf32(), "0".into()],
 				),
 			),
-			Ty::Vector3 => self.push_assign(into, self.readvector3()),
+			Ty::Vector3 => self.buf.push_assign(into, readvector3()),
 			Ty::Vector(x_ty, y_ty, z_ty) => {
 				let x_numty = match **x_ty {
 					Ty::Num(numty, range) => {
 						if self.checks {
-							self.push_range_check(into_expr.clone(), range);
+							self.buf.push_range_check(into_expr.clone(), range);
 						}
 
 						numty
@@ -568,7 +568,7 @@ impl Des<'_> {
 				let y_numty = match **y_ty {
 					Ty::Num(numty, range) => {
 						if self.checks {
-							self.push_range_check(into_expr.clone(), range);
+							self.buf.push_range_check(into_expr.clone(), range);
 						}
 
 						numty
@@ -579,7 +579,7 @@ impl Des<'_> {
 					match **z_ty {
 						Ty::Num(numty, range) => {
 							if self.checks {
-								self.push_range_check(into_expr.clone(), range);
+								self.buf.push_range_check(into_expr.clone(), range);
 							}
 
 							Some(numty)
@@ -590,19 +590,19 @@ impl Des<'_> {
 					None
 				};
 
-				self.push_assign(into, self.readvector(x_numty, y_numty, z_numty));
+				self.buf.push_assign(into, readvector(x_numty, y_numty, z_numty));
 			}
 
 			Ty::AlignedCFrame => {
 				let (axis_alignment_name, axis_alignment_expr) = self.add_occurrence("axis_alignment");
 
-				self.push_local(axis_alignment_name, Some(self.readu8()));
+				self.buf.push_local(axis_alignment_name, Some(readu8()));
 
 				let (pos_name, pos_expr) = self.add_occurrence("pos");
 
-				self.push_local(pos_name.clone(), Some(self.readvector3()));
+				self.buf.push_local(pos_name.clone(), Some(readvector3()));
 
-				self.push_assign(
+				self.buf.push_assign(
 					into,
 					Expr::Mul(
 						Box::new(Expr::Call(
@@ -620,11 +620,11 @@ impl Des<'_> {
 			}
 			Ty::CFrame => {
 				let (pos_name, pos_expr) = self.add_occurrence("pos");
-				self.push_local(pos_name.clone(), Some(self.readvector3()));
+				self.buf.push_local(pos_name.clone(), Some(readvector3()));
 				let (axisangle_name, axisangle_expr) = self.add_occurrence("axisangle");
-				self.push_local(axisangle_name.clone(), Some(self.readvector3()));
+				self.buf.push_local(axisangle_name.clone(), Some(readvector3()));
 				let (angle_name, angle_expr) = self.add_occurrence("angle");
-				self.push_local(
+				self.buf.push_local(
 					angle_name,
 					Some(Var::from(axisangle_name.as_str()).nindex("Magnitude").into()),
 				);
@@ -640,8 +640,9 @@ impl Des<'_> {
 				//		value = CFrame.new(pos)
 				// end
 
-				self.push_stmt(Stmt::If(Expr::Neq(Box::new(angle_expr.clone()), Box::new("0".into()))));
-				self.push_assign(
+				self.buf
+					.push(Stmt::If(Expr::Neq(Box::new(angle_expr.clone()), Box::new("0".into()))));
+				self.buf.push_assign(
 					into.clone(),
 					Expr::Add(
 						Box::new(Expr::Call(
@@ -652,8 +653,8 @@ impl Des<'_> {
 						Box::new(pos_expr.clone()),
 					),
 				);
-				self.push_stmt(Stmt::Else);
-				self.push_assign(
+				self.buf.push(Stmt::Else);
+				self.buf.push_assign(
 					into,
 					Expr::Call(
 						Box::new(Var::from("CFrame").nindex("new")),
@@ -661,7 +662,7 @@ impl Des<'_> {
 						vec![pos_expr.clone()],
 					),
 				);
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::End);
 			}
 		}
 	}
@@ -681,7 +682,7 @@ where
 		checks,
 		buf: OutputBuffer::new(),
 		var_occurrences,
-		scopes: vec![],
+		scopes: Default::default(),
 		typescript_enum_type,
 	}
 	.generate(names, types.into_iter())

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -157,7 +157,9 @@ impl Des<'_> {
 							Expr::StrOrBool(name.to_string()),
 						)])),
 					);
+					this.new_alloc_scope();
 					this.push_struct(struct_ty, into.clone());
+					this.end_alloc_scope();
 				});
 			}
 		}
@@ -387,6 +389,8 @@ impl Des<'_> {
 				let empty_expr = self.check_bitfield(empty_bits, empty_var);
 				self.buf.push(Stmt::If(empty_expr.not()));
 
+				self.new_alloc_scope();
+
 				let offset_len_expr = self.readnumty(length_numty);
 
 				self.buf.push(move || Stmt::NumFor {
@@ -414,6 +418,8 @@ impl Des<'_> {
 
 				self.buf.push(Stmt::End);
 
+				self.end_alloc_scope();
+
 				self.buf.push(Stmt::End);
 			}
 
@@ -425,6 +431,8 @@ impl Des<'_> {
 
 				let empty_expr = self.check_bitfield(empty_bits, empty_var);
 				self.buf.push(Stmt::If(empty_expr.not()));
+
+				self.new_alloc_scope();
 
 				let offset_len_expr = self.readnumty(length_numty);
 
@@ -448,6 +456,8 @@ impl Des<'_> {
 				self.end_alloc_scope();
 
 				self.buf.push(Stmt::End);
+
+				self.end_alloc_scope();
 
 				self.buf.push(Stmt::End);
 			}

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -72,6 +72,14 @@ pub trait Gen {
 	fn alloc_dynamic(&mut self, range: &Range, count: Expr) {
 		self.buf().clone().alloc_dynamic(self.scopes(), range, count);
 	}
+
+	fn readvector3(&mut self) -> Expr {
+		readvector3(self.scopes())
+	}
+
+	fn readvector(&mut self, x_numty: NumTy, y_numty: NumTy, z_numty: Option<NumTy>) -> Expr {
+		readvector(self.scopes(), x_numty, y_numty, z_numty)
+	}
 }
 
 enum OutputEntryKind {
@@ -153,15 +161,15 @@ impl OutputBuffer {
 		}
 	}
 
-	pub fn push_local(&mut self, name: String, expr: Option<Expr>) {
+	pub fn push_local(&self, name: String, expr: Option<Expr>) {
 		self.push(Stmt::Local(name, expr))
 	}
 
-	pub fn push_assign(&mut self, var: Var, expr: Expr) {
+	pub fn push_assign(&self, var: Var, expr: Expr) {
 		self.push(Stmt::Assign(var, expr))
 	}
 
-	pub fn push_assert(&mut self, expr: Expr, msg: String) {
+	pub fn push_assert(&self, expr: Expr, msg: String) {
 		self.push(Stmt::Assert(expr, msg))
 	}
 
@@ -204,7 +212,7 @@ impl OutputBuffer {
 		));
 	}
 
-	pub fn push_range_check(&mut self, expr: Expr, range: Range) {
+	pub fn push_range_check(&self, expr: Expr, range: Range) {
 		if let Some(min) = range.min() {
 			self.push_assert(expr.clone().gte(min.into()), format!("value is less than {min}!"))
 		}
@@ -214,7 +222,7 @@ impl OutputBuffer {
 		}
 	}
 
-	pub fn push_utf8_check(&mut self, expr: Expr) {
+	pub fn push_utf8_check(&self, expr: Expr) {
 		self.push_assert(
 			Var::NameIndex(Var::Name("utf8".into()).into(), "len".to_string())
 				.call(vec![expr])
@@ -274,17 +282,17 @@ macro_rules! numbers {
 			}
 
 			$(
-				fn [<read $ty>]() -> Expr {
+				pub fn [<read $ty>](scopes: &mut Scopes) -> Expr {
 					Var::from("buffer")
 						.nindex(concat!("read", stringify!($ty)))
 						.call(vec!["incoming_buff".into(), Var::from("read").call(vec![(NumTy::[<$ty:upper>].size() as f64).into()])])
 				}
 			)+
 
-			pub fn readnumty(numty: NumTy) -> Expr {
+			pub fn readnumty(scopes: &mut Scopes, numty: NumTy) -> Expr {
 				match numty {
 					$(
-						NumTy::[<$ty:upper>] => [<read $ty>]()
+						NumTy::[<$ty:upper>] => [<read $ty>](scopes)
 					),+
 				}
 			}
@@ -297,6 +305,10 @@ macro_rules! numbers {
 
 					fn [<push_write $ty>](&mut self, expr: Expr) {
 						self.buf().clone().[<push_write $ty>](&mut self.scopes(), expr);
+					}
+
+					fn [<read $ty>](&mut self) -> Expr {
+						[<read $ty>](&mut self.scopes())
 					}
 				)+
 
@@ -312,6 +324,14 @@ macro_rules! numbers {
 					match numty {
 						$(
 							NumTy::[<$ty:upper>] => self.buf().clone().[<push_write $ty>](&mut self.scopes(), expr)
+						),+
+					}
+				}
+
+				fn readnumty(&mut self, numty: NumTy) -> Expr {
+					match numty {
+						$(
+							NumTy::[<$ty:upper>] => [<read $ty>](&mut self.scopes())
 						),+
 					}
 				}
@@ -332,15 +352,19 @@ pub fn readstring(count: Expr) -> Expr {
 	])
 }
 
-pub fn readvector3() -> Expr {
-	Expr::Vector3(Box::new(readf32()), Box::new(readf32()), Box::new(readf32()))
+pub fn readvector3(scopes: &mut Scopes) -> Expr {
+	Expr::Vector3(
+		Box::new(readf32(scopes)),
+		Box::new(readf32(scopes)),
+		Box::new(readf32(scopes)),
+	)
 }
 
-pub fn readvector(x_numty: NumTy, y_numty: NumTy, z_numty: Option<NumTy>) -> Expr {
+pub fn readvector(scopes: &mut Scopes, x_numty: NumTy, y_numty: NumTy, z_numty: Option<NumTy>) -> Expr {
 	Expr::Vector(
-		Box::new(readnumty(x_numty)),
-		Box::new(readnumty(y_numty)),
-		z_numty.map(|z_numty| Box::new(readnumty(z_numty))),
+		Box::new(readnumty(scopes, x_numty)),
+		Box::new(readnumty(scopes, y_numty)),
+		z_numty.map(|z_numty| Box::new(readnumty(scopes, z_numty))),
 	)
 }
 

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -69,8 +69,8 @@ pub trait Gen {
 		self.buf().clone().push_write_copy(self.scopes(), expr, range, count);
 	}
 
-	fn alloc_dynamic(&mut self, range: &Range, count: Expr) -> Expr {
-		self.buf().clone().alloc_dynamic(self.scopes(), range, count)
+	fn alloc_dynamic(&mut self, range: &Range, count: Expr) {
+		self.buf().clone().alloc_dynamic(self.scopes(), range, count);
 	}
 }
 
@@ -128,7 +128,7 @@ impl OutputBuffer {
 		self.push(Stmt::Call(Var::from("alloc"), None, vec![expr]));
 	}
 
-	pub fn alloc_dynamic(&self, scopes: &mut Scopes, range: &Range, count: Expr) -> Expr {
+	pub fn alloc_dynamic(&self, scopes: &mut Scopes, range: &Range, mut count: Expr) {
 		let scope = scopes.alloc();
 
 		if let Some(exact) = range.exact() {
@@ -136,14 +136,15 @@ impl OutputBuffer {
 		} else {
 			if let Some(min) = range.min() {
 				scope.size += min as usize;
+				count = count.sub(min.into());
 			}
 
 			if let Some(max) = range.max() {
 				scope.max.add(max as usize);
 			}
-		}
 
-		alloc(count)
+			self.push_alloc(count);
+		}
 	}
 
 	pub fn push_local(&mut self, name: String, expr: Option<Expr>) {
@@ -223,13 +224,14 @@ macro_rules! numbers {
 			impl OutputBuffer {
 				$(
 					fn [<push_write $ty>](&mut self, scopes: &mut Scopes, expr: Expr) {
-						let offset = scopes.alloc().alloc(NumTy::[<$ty:upper>].size()) as f64;
+						let scope = scopes.alloc();
+						let offset = scope.alloc(NumTy::[<$ty:upper>].size()) as f64;
 						self.push(Stmt::Call(
 							Var::from("buffer").nindex(concat!("write", stringify!($ty))),
 							None,
 							vec![
 								"outgoing_buff".into(),
-								Expr::Var(Var::Name("outgoing_apos".into()).into()).add(offset.into()),
+								Expr::Var(Var::Name(scope.cursor_var.clone()).into()).add(offset.into()),
 								expr,
 							],
 						));
@@ -345,15 +347,17 @@ pub struct AllocScope {
 	pub multiplier: usize,
 	pub max: AllocMax,
 	pub buf: OutputBuffer,
+	pub cursor_var: String,
 }
 
 impl AllocScope {
-	pub fn new(buf: OutputBuffer) -> Self {
+	pub fn new(buf: OutputBuffer, cursor_var: String) -> Self {
 		Self {
 			size: 0,
 			multiplier: 1,
 			max: AllocMax::Unknown,
 			buf,
+			cursor_var,
 		}
 	}
 

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -73,11 +73,16 @@ pub trait Gen {
 		self.buf().clone().alloc_dynamic(self.scopes(), range, count);
 	}
 
-	fn readvector3(&mut self) -> Expr {
+	fn readvector3(&mut self) -> impl FnOnce() -> Expr + 'static + use<Self> {
 		readvector3(self.scopes())
 	}
 
-	fn readvector(&mut self, x_numty: NumTy, y_numty: NumTy, z_numty: Option<NumTy>) -> Expr {
+	fn readvector(
+		&mut self,
+		x_numty: NumTy,
+		y_numty: NumTy,
+		z_numty: Option<NumTy>,
+	) -> impl FnOnce() -> Expr + 'static + use<Self> {
 		readvector(self.scopes(), x_numty, y_numty, z_numty)
 	}
 }
@@ -110,6 +115,10 @@ impl From<OutputBuffer> for OutputEntry {
 
 pub fn alloc(expr: Expr) -> Expr {
 	Var::from("alloc").call(vec![expr])
+}
+
+pub fn read(expr: Expr) -> Expr {
+	Var::from("read").call(vec![expr])
 }
 
 #[derive(Default, Clone)]
@@ -206,7 +215,7 @@ impl OutputBuffer {
 				into.into(),
 				0.0.into(),
 				"incoming_buff".into(),
-				Var::from("read").call(vec![count.clone()]),
+				read(count.clone()),
 				count,
 			],
 		));
@@ -282,19 +291,49 @@ macro_rules! numbers {
 			}
 
 			$(
-				pub fn [<read $ty>](scopes: &mut Scopes) -> Expr {
-					Var::from("buffer")
-						.nindex(concat!("read", stringify!($ty)))
-						.call(vec!["incoming_buff".into(), Var::from("read").call(vec![(NumTy::[<$ty:upper>].size() as f64).into()])])
+				pub fn [<read $ty _raw>](scopes: &mut Scopes, immediate: bool) -> impl FnOnce() -> Expr + 'static + use<> {
+					let scope = scopes.alloc();
+					let (offset, dyn_offset) = scope.alloc(NumTy::[<$ty:upper>].size());
+					let cursor_var = scope.cursor_var.clone();
+
+					let make = move || {
+						let dyn_offset = (*dyn_offset.borrow()).clone();
+						let mut offset_expr = Expr::Num((if immediate { 0 } else { offset } + dyn_offset.offset) as f64);
+						if let Some(expr) = dyn_offset.expr {
+							offset_expr = offset_expr.add(expr);
+						}
+
+						Var::from("buffer")
+							.nindex(concat!("read", stringify!($ty)))
+							.call(vec!["incoming_buff".into(), Expr::Var(Var::Name(cursor_var).into()).add(offset_expr)])
+					};
+
+					let (value, make) = if immediate { (Some(make()), None) } else { (None, Some(make)) };
+
+					move || {
+						match (value, make) {
+							(Some(val), _) => val,
+							(_, Some(make)) => make(),
+							_ => unreachable!()
+						}
+					}
+				}
+
+				pub fn [<read $ty>](scopes: &mut Scopes) -> impl FnOnce() -> Expr + 'static + use<> {
+					[<read $ty _raw>](scopes, false)
 				}
 			)+
 
-			pub fn readnumty(scopes: &mut Scopes, numty: NumTy) -> Expr {
+			pub fn readnumty_raw(scopes: &mut Scopes, numty: NumTy, immediate: bool) -> Box<dyn FnOnce() -> Expr + 'static> {
 				match numty {
 					$(
-						NumTy::[<$ty:upper>] => [<read $ty>](scopes)
+						NumTy::[<$ty:upper>] => Box::new([<read $ty _raw>](scopes, immediate))
 					),+
 				}
+			}
+
+			pub fn readnumty(scopes: &mut Scopes, numty: NumTy) -> Box<dyn FnOnce() -> Expr + 'static> {
+				readnumty_raw(scopes, numty, false)
 			}
 
 			pub trait GenNumExt: Gen {
@@ -307,8 +346,12 @@ macro_rules! numbers {
 						self.buf().clone().[<push_write $ty>](&mut self.scopes(), expr);
 					}
 
-					fn [<read $ty>](&mut self) -> Expr {
-						[<read $ty>](&mut self.scopes())
+					fn [<read $ty _raw>](&mut self, immediate: bool) -> impl FnOnce() -> Expr + 'static + use<Self> {
+						[<read $ty _raw>](self.scopes(), immediate)
+					}
+
+					fn [<read $ty>](&mut self) -> impl FnOnce() -> Expr + 'static + use<Self> {
+						self.[<read $ty _raw>](false)
 					}
 				)+
 
@@ -328,12 +371,16 @@ macro_rules! numbers {
 					}
 				}
 
-				fn readnumty(&mut self, numty: NumTy) -> Expr {
+				fn readnumty_raw(&mut self, numty: NumTy, immediate: bool) -> Box<dyn FnOnce() -> Expr + 'static> {
 					match numty {
 						$(
-							NumTy::[<$ty:upper>] => [<read $ty>](&mut self.scopes())
+							NumTy::[<$ty:upper>] => Box::new([<read $ty _raw>](&mut self.scopes(), immediate))
 						),+
 					}
+				}
+
+				fn readnumty(&mut self, numty: NumTy) -> Box<dyn FnOnce() -> Expr + 'static> {
+					self.readnumty_raw(numty, false)
 				}
 			}
 
@@ -345,27 +392,30 @@ macro_rules! numbers {
 numbers!(f32, f64, u8, u16, u32, i8, i16, i32);
 
 pub fn readstring(count: Expr) -> Expr {
-	Var::from("buffer").nindex("readstring").call(vec![
-		"incoming_buff".into(),
-		Var::from("read").call(vec![count.clone()]),
-		count,
-	])
+	Var::from("buffer")
+		.nindex("readstring")
+		.call(vec!["incoming_buff".into(), read(count.clone()), count])
 }
 
-pub fn readvector3(scopes: &mut Scopes) -> Expr {
-	Expr::Vector3(
-		Box::new(readf32(scopes)),
-		Box::new(readf32(scopes)),
-		Box::new(readf32(scopes)),
-	)
+pub fn readvector3(scopes: &mut Scopes) -> impl FnOnce() -> Expr + 'static + use<> {
+	let x = readf32(scopes);
+	let y = readf32(scopes);
+	let z = readf32(scopes);
+
+	move || Expr::Vector3(Box::new(x()), Box::new(y()), Box::new(z()))
 }
 
-pub fn readvector(scopes: &mut Scopes, x_numty: NumTy, y_numty: NumTy, z_numty: Option<NumTy>) -> Expr {
-	Expr::Vector(
-		Box::new(readnumty(scopes, x_numty)),
-		Box::new(readnumty(scopes, y_numty)),
-		z_numty.map(|z_numty| Box::new(readnumty(scopes, z_numty))),
-	)
+pub fn readvector(
+	scopes: &mut Scopes,
+	x_numty: NumTy,
+	y_numty: NumTy,
+	z_numty: Option<NumTy>,
+) -> impl FnOnce() -> Expr + 'static + use<> {
+	let x = readnumty(scopes, x_numty);
+	let y = readnumty(scopes, y_numty);
+	let z = z_numty.map(|z_numty| readnumty(scopes, z_numty));
+
+	move || Expr::Vector(Box::new(x()), Box::new(y()), z.map(|z| Box::new(z())))
 }
 
 pub type BitpackMask = u16;

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -348,6 +348,7 @@ pub struct AllocScope {
 	pub max: AllocMax,
 	pub buf: OutputBuffer,
 	pub cursor_var: String,
+	pub offset: Rc<RefCell<usize>>,
 }
 
 impl AllocScope {
@@ -358,6 +359,7 @@ impl AllocScope {
 			max: AllocMax::Unknown,
 			buf,
 			cursor_var,
+			offset: Rc::new(RefCell::new(0)),
 		}
 	}
 
@@ -366,6 +368,10 @@ impl AllocScope {
 		let offset = self.size;
 		self.size += size;
 		offset
+	}
+
+	pub fn offset_by(&self, offset: usize) {
+		*self.offset.borrow_mut() += offset;
 	}
 }
 

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -74,18 +74,23 @@ pub trait Gen {
 	}
 }
 
-#[derive(Debug)]
 enum OutputEntryKind {
 	Stmt(Stmt),
+	LazyStmt(Box<dyn FnOnce() -> Stmt>),
 	Buffer(OutputBuffer),
 }
 
-#[derive(Debug)]
 pub struct OutputEntry(OutputEntryKind);
 
 impl From<Stmt> for OutputEntry {
 	fn from(value: Stmt) -> Self {
 		OutputEntry(OutputEntryKind::Stmt(value))
+	}
+}
+
+impl<F: FnOnce() -> Stmt + 'static> From<F> for OutputEntry {
+	fn from(value: F) -> Self {
+		OutputEntry(OutputEntryKind::LazyStmt(Box::new(value)))
 	}
 }
 
@@ -99,7 +104,7 @@ pub fn alloc(expr: Expr) -> Expr {
 	Var::from("alloc").call(vec![expr])
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
 pub struct OutputBuffer(Rc<RefCell<Vec<OutputEntry>>>);
 
 impl OutputBuffer {
@@ -117,6 +122,7 @@ impl OutputBuffer {
 		for entry in self.0.take() {
 			match entry.0 {
 				OutputEntryKind::Stmt(stmt) => output.push(stmt),
+				OutputEntryKind::LazyStmt(make) => output.push(make()),
 				OutputEntryKind::Buffer(buf) => output.extend(buf.output()),
 			}
 		}
@@ -223,18 +229,38 @@ macro_rules! numbers {
 		paste::paste! {
 			impl OutputBuffer {
 				$(
-					fn [<push_write $ty>](&mut self, scopes: &mut Scopes, expr: Expr) {
+					fn [<push_write $ty _raw>](&mut self, scopes: &mut Scopes, expr: Expr, immediate: bool) {
 						let scope = scopes.alloc();
-						let offset = scope.alloc(NumTy::[<$ty:upper>].size()) as f64;
-						self.push(Stmt::Call(
-							Var::from("buffer").nindex(concat!("write", stringify!($ty))),
-							None,
-							vec![
-								"outgoing_buff".into(),
-								Expr::Var(Var::Name(scope.cursor_var.clone()).into()).add(offset.into()),
-								expr,
-							],
-						));
+						let (offset, dyn_offset) = scope.alloc(NumTy::[<$ty:upper>].size());
+						let cursor_var = scope.cursor_var.clone();
+
+						let make = move || {
+							let dyn_offset = (*dyn_offset.borrow()).clone();
+							let mut offset_expr = Expr::Num((if immediate { 0 } else { offset } + dyn_offset.offset) as f64);
+							if let Some(expr) = dyn_offset.expr {
+								offset_expr = offset_expr.add(expr);
+							}
+
+							Stmt::Call(
+								Var::from("buffer").nindex(concat!("write", stringify!($ty))),
+								None,
+								vec![
+									"outgoing_buff".into(),
+									Expr::Var(Var::Name(cursor_var).into()).add(offset_expr),
+									expr,
+								],
+							)
+						};
+
+						if immediate {
+							self.push(make());
+						} else {
+							self.push(make);
+						}
+					}
+
+					fn [<push_write $ty>](&mut self, scopes: &mut Scopes, expr: Expr) {
+						self.[<push_write $ty _raw>](scopes, expr, false);
 					}
 				)+
 
@@ -265,10 +291,22 @@ macro_rules! numbers {
 
 			pub trait GenNumExt: Gen {
 				$(
+					fn [<push_write $ty _raw>](&mut self, expr: Expr, immediate: bool) {
+						self.buf().clone().[<push_write $ty _raw>](&mut self.scopes(), expr, immediate);
+					}
+
 					fn [<push_write $ty>](&mut self, expr: Expr) {
 						self.buf().clone().[<push_write $ty>](&mut self.scopes(), expr);
 					}
 				)+
+
+				fn push_writenumty_raw(&mut self, expr: Expr, numty: NumTy, immediate: bool) {
+					match numty {
+						$(
+							NumTy::[<$ty:upper>] => self.buf().clone().[<push_write $ty _raw>](&mut self.scopes(), expr, immediate)
+						),+
+					}
+				}
 
 				fn push_writenumty(&mut self, expr: Expr, numty: NumTy) {
 					match numty {
@@ -308,7 +346,6 @@ pub fn readvector(x_numty: NumTy, y_numty: NumTy, z_numty: Option<NumTy>) -> Exp
 
 pub type BitpackMask = u16;
 
-#[derive(Debug)]
 pub struct DynamicScope {
 	pub bitpack_budget: Vec<(u8, String)>,
 	pub buf: OutputBuffer,
@@ -340,7 +377,12 @@ impl AllocMax {
 	}
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default, Clone)]
+pub struct LazyAllocData {
+	pub offset: usize,
+	pub expr: Option<Expr>,
+}
+
 #[must_use]
 pub struct AllocScope {
 	pub size: usize,
@@ -348,7 +390,7 @@ pub struct AllocScope {
 	pub max: AllocMax,
 	pub buf: OutputBuffer,
 	pub cursor_var: String,
-	pub offset: Rc<RefCell<usize>>,
+	pub offset: Rc<RefCell<LazyAllocData>>,
 }
 
 impl AllocScope {
@@ -359,23 +401,27 @@ impl AllocScope {
 			max: AllocMax::Unknown,
 			buf,
 			cursor_var,
-			offset: Rc::new(RefCell::new(0)),
+			offset: Rc::new(RefCell::new(LazyAllocData::default())),
 		}
 	}
 
 	#[must_use]
-	pub fn alloc(&mut self, size: usize) -> usize {
+	pub fn alloc(&mut self, size: usize) -> (usize, Rc<RefCell<LazyAllocData>>) {
 		let offset = self.size;
 		self.size += size;
-		offset
+		(offset, self.offset.clone())
 	}
 
 	pub fn offset_by(&self, offset: usize) {
-		*self.offset.borrow_mut() += offset;
+		self.offset.borrow_mut().offset += offset;
+	}
+
+	pub fn offset_expr(&self, expr: Expr) {
+		self.offset.borrow_mut().expr = Some(expr);
 	}
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct Scopes {
 	pub dynamic: Vec<DynamicScope>,
 	pub alloc: Vec<AllocScope>,
@@ -651,9 +697,9 @@ impl Display for Expr {
 			Self::Lt(lhs, rhs) => write!(f, "{lhs} < {rhs}"),
 			Self::Eq(lhs, rhs) => write!(f, "{lhs} == {rhs}"),
 
-			Self::Add(lhs, rhs) => write!(f, "{lhs} + {rhs}"),
-			Self::Sub(lhs, rhs) => write!(f, "{lhs} - {rhs}"),
-			Self::Mul(lhs, rhs) => write!(f, "{lhs} * {rhs}"),
+			Self::Add(lhs, rhs) => write!(f, "({lhs} + {rhs})"),
+			Self::Sub(lhs, rhs) => write!(f, "({lhs} - {rhs})"),
+			Self::Mul(lhs, rhs) => write!(f, "({lhs} * {rhs})"),
 		}
 	}
 }

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -314,13 +314,12 @@ macro_rules! numbers {
 							.call(vec!["incoming_buff".into(), Expr::Var(Var::Name(cursor_var).into()).add(offset_expr)])
 					};
 
-					let (value, make) = if immediate { (Some(make()), None) } else { (None, Some(make)) };
+					let value = if immediate { Either::Left(make()) } else { Either::Right(make) };
 
 					move || {
-						match (value, make) {
-							(Some(val), _) => val,
-							(_, Some(make)) => make(),
-							_ => unreachable!()
+						match value {
+							Either::Left(val) => val,
+							Either::Right(make) => make(),
 						}
 					}
 				}

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -7,262 +7,10 @@ pub mod des;
 pub mod ser;
 
 pub trait Gen {
-	fn push_stmt(&mut self, stmt: Stmt);
+	fn buf(&self) -> &OutputBuffer;
 	fn generate<'a, 'src: 'a, I>(self, names: &[String], types: I) -> Vec<Stmt>
 	where
 		I: Iterator<Item = &'a Ty<'src>>;
-
-	fn push_local(&mut self, name: String, expr: Option<Expr>) {
-		self.push_stmt(Stmt::Local(name, expr))
-	}
-
-	fn push_assign(&mut self, var: Var, expr: Expr) {
-		self.push_stmt(Stmt::Assign(var, expr))
-	}
-
-	fn push_assert(&mut self, expr: Expr, msg: String) {
-		self.push_stmt(Stmt::Assert(expr, msg))
-	}
-
-	fn push_alloc(&mut self, expr: Expr) {
-		self.push_stmt(Stmt::Call(Var::from("alloc"), None, vec![expr]));
-	}
-
-	fn push_writef32(&mut self, expr: Expr) {
-		self.push_alloc(4.0.into());
-
-		self.push_stmt(Stmt::Call(
-			Var::from("buffer").nindex("writef32"),
-			None,
-			vec!["outgoing_buff".into(), "outgoing_apos".into(), expr],
-		));
-	}
-
-	fn push_writef64(&mut self, expr: Expr) {
-		self.push_alloc(8.0.into());
-
-		self.push_stmt(Stmt::Call(
-			Var::from("buffer").nindex("writef64"),
-			None,
-			vec!["outgoing_buff".into(), "outgoing_apos".into(), expr],
-		));
-	}
-
-	fn push_writeu8(&mut self, expr: Expr) {
-		self.push_alloc(1.0.into());
-
-		self.push_stmt(Stmt::Call(
-			Var::from("buffer").nindex("writeu8"),
-			None,
-			vec!["outgoing_buff".into(), "outgoing_apos".into(), expr],
-		));
-	}
-
-	fn push_writeu16(&mut self, expr: Expr) {
-		self.push_alloc(2.0.into());
-
-		self.push_stmt(Stmt::Call(
-			Var::from("buffer").nindex("writeu16"),
-			None,
-			vec!["outgoing_buff".into(), "outgoing_apos".into(), expr],
-		));
-	}
-
-	fn push_writeu32(&mut self, expr: Expr) {
-		self.push_alloc(4.0.into());
-
-		self.push_stmt(Stmt::Call(
-			Var::from("buffer").nindex("writeu32"),
-			None,
-			vec!["outgoing_buff".into(), "outgoing_apos".into(), expr],
-		));
-	}
-
-	fn push_writei8(&mut self, expr: Expr) {
-		self.push_alloc(1.0.into());
-
-		self.push_stmt(Stmt::Call(
-			Var::from("buffer").nindex("writei8"),
-			None,
-			vec!["outgoing_buff".into(), "outgoing_apos".into(), expr],
-		));
-	}
-
-	fn push_writei16(&mut self, expr: Expr) {
-		self.push_alloc(2.0.into());
-
-		self.push_stmt(Stmt::Call(
-			Var::from("buffer").nindex("writei16"),
-			None,
-			vec!["outgoing_buff".into(), "outgoing_apos".into(), expr],
-		));
-	}
-
-	fn push_writei32(&mut self, expr: Expr) {
-		self.push_alloc(4.0.into());
-
-		self.push_stmt(Stmt::Call(
-			Var::from("buffer").nindex("writei32"),
-			None,
-			vec!["outgoing_buff".into(), "outgoing_apos".into(), expr],
-		));
-	}
-
-	fn push_writenumty(&mut self, expr: Expr, numty: NumTy) {
-		match numty {
-			NumTy::F32 => self.push_writef32(expr),
-			NumTy::F64 => self.push_writef64(expr),
-			NumTy::U8 => self.push_writeu8(expr),
-			NumTy::U16 => self.push_writeu16(expr),
-			NumTy::U32 => self.push_writeu32(expr),
-			NumTy::I8 => self.push_writei8(expr),
-			NumTy::I16 => self.push_writei16(expr),
-			NumTy::I32 => self.push_writei32(expr),
-		}
-	}
-
-	fn push_writestring(&mut self, expr: Expr, count: Expr) {
-		self.push_alloc(count.clone());
-
-		self.push_stmt(Stmt::Call(
-			Var::from("buffer").nindex("writestring"),
-			None,
-			vec!["outgoing_buff".into(), "outgoing_apos".into(), expr, count],
-		));
-	}
-
-	fn readf32(&self) -> Expr {
-		Var::from("buffer")
-			.nindex("readf32")
-			.call(vec!["incoming_buff".into(), Var::from("read").call(vec![4.0.into()])])
-	}
-
-	fn readf64(&self) -> Expr {
-		Var::from("buffer")
-			.nindex("readf64")
-			.call(vec!["incoming_buff".into(), Var::from("read").call(vec![8.0.into()])])
-	}
-
-	fn readu8(&self) -> Expr {
-		Var::from("buffer")
-			.nindex("readu8")
-			.call(vec!["incoming_buff".into(), Var::from("read").call(vec![1.0.into()])])
-	}
-
-	fn readu16(&self) -> Expr {
-		Var::from("buffer")
-			.nindex("readu16")
-			.call(vec!["incoming_buff".into(), Var::from("read").call(vec![2.0.into()])])
-	}
-
-	fn readu32(&self) -> Expr {
-		Var::from("buffer")
-			.nindex("readu32")
-			.call(vec!["incoming_buff".into(), Var::from("read").call(vec![4.0.into()])])
-	}
-
-	fn readi8(&self) -> Expr {
-		Var::from("buffer")
-			.nindex("readi8")
-			.call(vec!["incoming_buff".into(), Var::from("read").call(vec![1.0.into()])])
-	}
-
-	fn readi16(&self) -> Expr {
-		Var::from("buffer")
-			.nindex("readi16")
-			.call(vec!["incoming_buff".into(), Var::from("read").call(vec![2.0.into()])])
-	}
-
-	fn readi32(&self) -> Expr {
-		Var::from("buffer")
-			.nindex("readi32")
-			.call(vec!["incoming_buff".into(), Var::from("read").call(vec![4.0.into()])])
-	}
-
-	fn readnumty(&self, numty: NumTy) -> Expr {
-		match numty {
-			NumTy::F32 => self.readf32(),
-			NumTy::F64 => self.readf64(),
-			NumTy::U8 => self.readu8(),
-			NumTy::U16 => self.readu16(),
-			NumTy::U32 => self.readu32(),
-			NumTy::I8 => self.readi8(),
-			NumTy::I16 => self.readi16(),
-			NumTy::I32 => self.readi32(),
-		}
-	}
-
-	fn readstring(&self, count: Expr) -> Expr {
-		Var::from("buffer").nindex("readstring").call(vec![
-			"incoming_buff".into(),
-			Var::from("read").call(vec![count.clone()]),
-			count,
-		])
-	}
-
-	fn readvector3(&self) -> Expr {
-		Expr::Vector3(
-			Box::new(self.readf32()),
-			Box::new(self.readf32()),
-			Box::new(self.readf32()),
-		)
-	}
-
-	fn readvector(&self, x_numty: NumTy, y_numty: NumTy, z_numty: Option<NumTy>) -> Expr {
-		Expr::Vector(
-			Box::new(self.readnumty(x_numty)),
-			Box::new(self.readnumty(y_numty)),
-			z_numty.map(|z_numty| Box::new(self.readnumty(z_numty))),
-		)
-	}
-
-	fn push_write_copy(&mut self, expr: Expr, count: Expr) {
-		self.push_alloc(count.clone());
-
-		self.push_stmt(Stmt::Call(
-			Var::from("buffer").nindex("copy"),
-			None,
-			vec!["outgoing_buff".into(), "outgoing_apos".into(), expr, 0.0.into(), count],
-		));
-	}
-
-	fn push_read_copy(&mut self, into: Var, count: Expr) {
-		self.push_assign(
-			into.clone(),
-			Var::from("buffer").nindex("create").call(vec![count.clone()]),
-		);
-
-		self.push_stmt(Stmt::Call(
-			Var::from("buffer").nindex("copy"),
-			None,
-			vec![
-				into.into(),
-				0.0.into(),
-				"incoming_buff".into(),
-				Var::from("read").call(vec![count.clone()]),
-				count,
-			],
-		));
-	}
-
-	fn push_range_check(&mut self, expr: Expr, range: Range) {
-		if let Some(min) = range.min() {
-			self.push_assert(expr.clone().gte(min.into()), format!("value is less than {min}!"))
-		}
-
-		if let Some(max) = range.max() {
-			self.push_assert(expr.clone().lte(max.into()), format!("value is more than {max}!"))
-		}
-	}
-
-	fn push_utf8_check(&mut self, expr: Expr) {
-		self.push_assert(
-			Var::NameIndex(Var::Name("utf8".into()).into(), "len".to_string())
-				.call(vec![expr])
-				.neq(Expr::Nil),
-			"value is not valid utf-8".into(),
-		);
-	}
 
 	fn get_var_occurrences(&mut self) -> &mut HashMap<String, usize>;
 	fn add_occurrence(&mut self, name: &str) -> (String, Expr) {
@@ -281,23 +29,21 @@ pub trait Gen {
 		}
 	}
 
-	fn new_scope(&mut self);
-	fn current_scope(&mut self) -> &mut Scope;
-	fn end_scope(&mut self);
+	fn scopes(&mut self) -> &mut Scopes;
 
 	fn get_bitpack(&mut self) -> (BitpackMask, Var) {
-		let scope = self.current_scope();
-
-		let existing = scope
+		if let Some(existing) = self
+			.scopes()
+			.dynamic()
 			.bitpack_budget
 			.last_mut()
-			.filter(|(shift, _)| *shift < (BitpackMask::BITS as u8 - 1));
-		if let Some(existing) = existing {
+			.filter(|(shift, _)| *shift < (BitpackMask::BITS as u8 - 1))
+		{
 			existing.0 += 1;
 			(1 << existing.0, Var::Name(existing.1.clone()))
 		} else {
 			let (name, _) = self.add_occurrence("bool");
-			self.current_scope().bitpack_budget.push((0, name.clone()));
+			self.scopes().dynamic().bitpack_budget.push((0, name.clone()));
 			(1, Var::Name(name))
 		}
 	}
@@ -308,11 +54,23 @@ pub trait Gen {
 			// 0 is variant 1, 1 is variant 2
 		} else if amount == 2 {
 			VariantStorageKind::Bit(self.get_bitpack())
-		} else if self.current_scope().remaining_bitpack_budget() as usize >= amount {
+		} else if self.scopes().dynamic().remaining_bitpack_budget() as usize >= amount {
 			VariantStorageKind::Bitpack(iter::repeat_with(|| self.get_bitpack()).take(amount).collect())
 		} else {
 			VariantStorageKind::Full(NumTy::from_f64(0.0, amount as f64 - 1.0), amount)
 		}
+	}
+
+	fn push_writestring(&mut self, expr: Expr, range: &Range, count: Expr) {
+		self.buf().clone().push_writestring(self.scopes(), expr, range, count);
+	}
+
+	fn push_write_copy(&mut self, expr: Expr, range: &Range, count: Expr) {
+		self.buf().clone().push_write_copy(self.scopes(), expr, range, count);
+	}
+
+	fn alloc_dynamic(&mut self, range: &Range, count: Expr) -> Expr {
+		self.buf().clone().alloc_dynamic(self.scopes(), range, count)
 	}
 }
 
@@ -335,6 +93,10 @@ impl From<OutputBuffer> for OutputEntry {
 	fn from(value: OutputBuffer) -> Self {
 		OutputEntry(OutputEntryKind::Buffer(value))
 	}
+}
+
+pub fn alloc(expr: Expr) -> Expr {
+	Var::from("alloc").call(vec![expr])
 }
 
 #[derive(Debug, Default, Clone)]
@@ -361,22 +123,261 @@ impl OutputBuffer {
 
 		output
 	}
+
+	pub fn push_alloc(&self, expr: Expr) {
+		self.push(Stmt::Call(Var::from("alloc"), None, vec![expr]));
+	}
+
+	pub fn alloc_dynamic(&self, scopes: &mut Scopes, range: &Range, count: Expr) -> Expr {
+		let scope = scopes.alloc();
+
+		if let Some(exact) = range.exact() {
+			scope.size += exact as usize;
+		} else {
+			if let Some(min) = range.min() {
+				scope.size += min as usize;
+			}
+
+			if let Some(max) = range.max() {
+				scope.max.add(max as usize);
+			}
+		}
+
+		alloc(count)
+	}
+
+	pub fn push_local(&mut self, name: String, expr: Option<Expr>) {
+		self.push(Stmt::Local(name, expr))
+	}
+
+	pub fn push_assign(&mut self, var: Var, expr: Expr) {
+		self.push(Stmt::Assign(var, expr))
+	}
+
+	pub fn push_assert(&mut self, expr: Expr, msg: String) {
+		self.push(Stmt::Assert(expr, msg))
+	}
+
+	pub fn push_writestring(&mut self, scopes: &mut Scopes, expr: Expr, range: &Range, count: Expr) {
+		self.alloc_dynamic(scopes, range, count.clone());
+
+		self.push(Stmt::Call(
+			Var::from("buffer").nindex("writestring"),
+			None,
+			vec!["outgoing_buff".into(), "outgoing_apos".into(), expr, count],
+		));
+	}
+
+	pub fn push_write_copy(&mut self, scopes: &mut Scopes, expr: Expr, range: &Range, count: Expr) {
+		self.alloc_dynamic(scopes, range, count.clone());
+
+		self.push(Stmt::Call(
+			Var::from("buffer").nindex("copy"),
+			None,
+			vec!["outgoing_buff".into(), "outgoing_apos".into(), expr, 0.0.into(), count],
+		));
+	}
+
+	pub fn push_read_copy(&mut self, into: Var, count: Expr) {
+		self.push_assign(
+			into.clone(),
+			Var::from("buffer").nindex("create").call(vec![count.clone()]),
+		);
+
+		self.push(Stmt::Call(
+			Var::from("buffer").nindex("copy"),
+			None,
+			vec![
+				into.into(),
+				0.0.into(),
+				"incoming_buff".into(),
+				Var::from("read").call(vec![count.clone()]),
+				count,
+			],
+		));
+	}
+
+	pub fn push_range_check(&mut self, expr: Expr, range: Range) {
+		if let Some(min) = range.min() {
+			self.push_assert(expr.clone().gte(min.into()), format!("value is less than {min}!"))
+		}
+
+		if let Some(max) = range.max() {
+			self.push_assert(expr.clone().lte(max.into()), format!("value is more than {max}!"))
+		}
+	}
+
+	pub fn push_utf8_check(&mut self, expr: Expr) {
+		self.push_assert(
+			Var::NameIndex(Var::Name("utf8".into()).into(), "len".to_string())
+				.call(vec![expr])
+				.neq(Expr::Nil),
+			"value is not valid utf-8".into(),
+		);
+	}
+}
+
+macro_rules! numbers {
+	($($ty:ident),+) => {
+		paste::paste! {
+			impl OutputBuffer {
+				$(
+					fn [<push_write $ty>](&mut self, scopes: &mut Scopes, expr: Expr) {
+						let offset = scopes.alloc().alloc(NumTy::[<$ty:upper>].size()) as f64;
+						self.push(Stmt::Call(
+							Var::from("buffer").nindex(concat!("write", stringify!($ty))),
+							None,
+							vec![
+								"outgoing_buff".into(),
+								Expr::Var(Var::Name("outgoing_apos".into()).into()).add(offset.into()),
+								expr,
+							],
+						));
+					}
+				)+
+
+				// fn push_writenumty(&mut self, scopes: &mut Scopes, expr: Expr, numty: NumTy) {
+				// 	match numty {
+				// 		$(
+				// 			NumTy::[<$ty:upper>] => self.[<push_write $ty>](scopes, expr)
+				// 		),+
+				// 	}
+				// }
+			}
+
+			$(
+				fn [<read $ty>]() -> Expr {
+					Var::from("buffer")
+						.nindex(concat!("read", stringify!($ty)))
+						.call(vec!["incoming_buff".into(), Var::from("read").call(vec![(NumTy::[<$ty:upper>].size() as f64).into()])])
+				}
+			)+
+
+			pub fn readnumty(numty: NumTy) -> Expr {
+				match numty {
+					$(
+						NumTy::[<$ty:upper>] => [<read $ty>]()
+					),+
+				}
+			}
+
+			pub trait GenNumExt: Gen {
+				$(
+					fn [<push_write $ty>](&mut self, expr: Expr) {
+						self.buf().clone().[<push_write $ty>](&mut self.scopes(), expr);
+					}
+				)+
+
+				fn push_writenumty(&mut self, expr: Expr, numty: NumTy) {
+					match numty {
+						$(
+							NumTy::[<$ty:upper>] => self.buf().clone().[<push_write $ty>](&mut self.scopes(), expr)
+						),+
+					}
+				}
+			}
+
+			impl<T: Gen> GenNumExt for T {}
+		}
+	};
+}
+
+numbers!(f32, f64, u8, u16, u32, i8, i16, i32);
+
+pub fn readstring(count: Expr) -> Expr {
+	Var::from("buffer").nindex("readstring").call(vec![
+		"incoming_buff".into(),
+		Var::from("read").call(vec![count.clone()]),
+		count,
+	])
+}
+
+pub fn readvector3() -> Expr {
+	Expr::Vector3(Box::new(readf32()), Box::new(readf32()), Box::new(readf32()))
+}
+
+pub fn readvector(x_numty: NumTy, y_numty: NumTy, z_numty: Option<NumTy>) -> Expr {
+	Expr::Vector(
+		Box::new(readnumty(x_numty)),
+		Box::new(readnumty(y_numty)),
+		z_numty.map(|z_numty| Box::new(readnumty(z_numty))),
+	)
 }
 
 pub type BitpackMask = u16;
 
 #[derive(Debug)]
-pub struct Scope {
+pub struct DynamicScope {
 	pub bitpack_budget: Vec<(u8, String)>,
 	pub buf: OutputBuffer,
 }
 
-impl Scope {
+impl DynamicScope {
 	pub fn remaining_bitpack_budget(&self) -> u8 {
 		self.bitpack_budget
 			.last()
 			.map(|(shift, _)| BitpackMask::BITS as u8 - (shift + 1))
 			.unwrap_or(BitpackMask::BITS as u8)
+	}
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum AllocMax {
+	Unbounded,
+	Unknown,
+	Max(usize),
+}
+
+impl AllocMax {
+	pub fn add(&mut self, max: usize) {
+		match self {
+			AllocMax::Unbounded => {}
+			AllocMax::Unknown => *self = AllocMax::Max(max),
+			AllocMax::Max(present) => *present += max,
+		}
+	}
+}
+
+#[derive(Debug)]
+#[must_use]
+pub struct AllocScope {
+	pub size: usize,
+	pub multiplier: usize,
+	pub max: AllocMax,
+	pub buf: OutputBuffer,
+}
+
+impl AllocScope {
+	pub fn new(buf: OutputBuffer) -> Self {
+		Self {
+			size: 0,
+			multiplier: 1,
+			max: AllocMax::Unknown,
+			buf,
+		}
+	}
+
+	#[must_use]
+	pub fn alloc(&mut self, size: usize) -> usize {
+		let offset = self.size;
+		self.size += size;
+		offset
+	}
+}
+
+#[derive(Debug, Default)]
+pub struct Scopes {
+	pub dynamic: Vec<DynamicScope>,
+	pub alloc: Vec<AllocScope>,
+}
+
+impl Scopes {
+	pub fn dynamic(&mut self) -> &mut DynamicScope {
+		self.dynamic.last_mut().unwrap()
+	}
+
+	pub fn alloc(&mut self) -> &mut AllocScope {
+		self.alloc.last_mut().unwrap()
 	}
 }
 
@@ -539,6 +540,10 @@ impl Expr {
 
 	pub fn sub(self, other: Self) -> Self {
 		Self::Sub(Box::new(self), Box::new(other))
+	}
+
+	pub fn mul(self, other: Self) -> Self {
+		Self::Mul(Box::new(self), Box::new(other))
 	}
 }
 

--- a/zap/src/irgen/mod.rs
+++ b/zap/src/irgen/mod.rs
@@ -133,6 +133,12 @@ impl OutputBuffer {
 		self.0.borrow_mut().push(item.into());
 	}
 
+	pub fn insert(&self) -> OutputBuffer {
+		let buf = OutputBuffer::new();
+		self.push(buf.clone());
+		buf
+	}
+
 	pub fn output(self) -> Vec<Stmt> {
 		let mut output = vec![];
 
@@ -774,6 +780,28 @@ impl Display for Expr {
 			Self::Add(lhs, rhs) => write!(f, "({lhs} + {rhs})"),
 			Self::Sub(lhs, rhs) => write!(f, "({lhs} - {rhs})"),
 			Self::Mul(lhs, rhs) => write!(f, "({lhs} * {rhs})"),
+		}
+	}
+}
+
+#[derive(Debug, Clone)]
+pub enum Either<L, R> {
+	Left(L),
+	Right(R),
+}
+
+impl<L, R> Either<L, R> {
+	pub fn left(self) -> L {
+		match self {
+			Either::Left(l) => l,
+			_ => unreachable!(),
+		}
+	}
+
+	pub fn right(self) -> R {
+		match self {
+			Self::Right(r) => r,
+			_ => unreachable!(),
 		}
 	}
 }

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -58,7 +58,7 @@ impl Ser<'_> {
 	}
 
 	fn end_alloc_scope_complex(&mut self, cb: impl FnOnce(Expr) -> Expr, offset: usize) {
-		let mut scope = self.scopes.alloc.pop().unwrap();
+		let scope = self.scopes.alloc.pop().unwrap();
 		scope.offset_by(offset);
 		let size_expr = Expr::Num(scope.size as f64);
 		scope.buf.push_local(scope.cursor_var, Some(alloc(cb(size_expr))));

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -295,9 +295,7 @@ impl Ser<'_> {
 		self.buf.push(Stmt::Else);
 		if let Some(unknown_i) = unknown_i {
 			self.push_variant_storage(&storage, unknown_i);
-			self.new_alloc_scope();
 			self.push_ty(&Ty::Unknown, from.clone());
-			self.end_alloc_scope();
 		} else {
 			self.buf.push(Stmt::Error("Invalid type".into()));
 		}
@@ -447,11 +445,11 @@ impl Ser<'_> {
 
 					self.end_dyn_scope();
 
+					self.buf.push(Stmt::End);
+
 					let scope = self.scopes.alloc();
 					scope.offset_expr(var_expr.clone().sub(1.0.into()).mul((scope.size as f64).into()));
 					self.end_alloc_scope_complex(|expr| expr.mul(len_expr), 0);
-
-					self.buf.push(Stmt::End);
 				}
 			}
 

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -1,35 +1,38 @@
 use crate::{
 	config::{Enum, NumTy, PrimitiveTy, Struct, Ty, TypeScriptEnumType},
-	irgen::{BitpackMask, OutputBuffer, Scope, VariantStorageKind},
+	irgen::{AllocScope, BitpackMask, DynamicScope, OutputBuffer, Scopes, VariantStorageKind, alloc},
 };
 use std::collections::HashMap;
 
-use super::{Expr, Gen, Stmt, Var};
+use super::{Expr, Gen, GenNumExt, Stmt, Var};
 
 struct Ser<'src> {
 	checks: bool,
 	buf: OutputBuffer,
 	var_occurrences: &'src mut HashMap<String, usize>,
-	scopes: Vec<Scope>,
+	scopes: Scopes,
 	typescript_enum_type: TypeScriptEnumType,
 }
 
 impl Gen for Ser<'_> {
-	fn push_stmt(&mut self, stmt: Stmt) {
-		self.buf.push(stmt);
+	fn buf(&self) -> &OutputBuffer {
+		&self.buf
 	}
 
 	fn generate<'a, 'src: 'a, I>(mut self, names: &[String], types: I) -> Vec<Stmt>
 	where
 		I: Iterator<Item = &'a Ty<'src>>,
 	{
-		self.new_scope();
+		self.new_alloc_scope();
+		self.new_dyn_scope();
 
 		for (ty, name) in types.zip(names) {
 			self.push_ty(ty, Var::Name(name.to_string()));
 		}
 
-		self.end_scope();
+		self.end_dyn_scope();
+		let scope = self.end_alloc_scope();
+		scope.buf.push_alloc((scope.size as f64).into());
 
 		self.buf.output()
 	}
@@ -38,49 +41,42 @@ impl Gen for Ser<'_> {
 		self.var_occurrences
 	}
 
-	fn new_scope(&mut self) {
+	fn scopes(&mut self) -> &mut Scopes {
+		&mut self.scopes
+	}
+}
+
+impl Ser<'_> {
+	fn new_alloc_scope(&mut self) {
 		let scope_buf = OutputBuffer::new();
 		self.buf.push(scope_buf.clone());
-		self.scopes.push(Scope {
+		self.scopes.alloc.push(AllocScope::new(scope_buf));
+	}
+
+	fn end_alloc_scope(&mut self) -> AllocScope {
+		self.scopes.alloc.pop().unwrap()
+	}
+
+	fn new_dyn_scope(&mut self) {
+		let scope_buf = OutputBuffer::new();
+		self.buf.push(scope_buf.clone());
+		self.scopes.dynamic.push(DynamicScope {
 			bitpack_budget: vec![],
 			buf: scope_buf,
 		});
 	}
 
-	fn current_scope(&mut self) -> &mut Scope {
-		self.scopes.last_mut().unwrap()
-	}
-
-	fn end_scope(&mut self) {
-		let scope = self.scopes.pop().unwrap();
+	fn end_dyn_scope(&mut self) {
+		let scope = self.scopes.dynamic.pop().unwrap();
 
 		for (shift, name) in scope.bitpack_budget {
-			let (pos_name, pos_expr) = self.add_occurrence(&format!("{name}_pos"));
 			let numty = NumTy::from_f64(0.0, ((1u64 << (shift + 1)) - 1) as f64);
 
 			scope.buf.push(Stmt::Local(name.clone(), Some(Expr::Num(0.0))));
-			scope.buf.push(Stmt::Local(
-				pos_name,
-				Some(Expr::Call(
-					Var::Name("alloc".into()).into(),
-					None,
-					vec![Expr::Num(numty.size() as f64)],
-				)),
-			));
-			self.buf.push(Stmt::Call(
-				Var::NameIndex(Var::Name("buffer".into()).into(), format!("write{numty}")),
-				None,
-				vec![
-					Expr::Var(Var::Name("outgoing_buff".into()).into()),
-					pos_expr,
-					Expr::Var(Var::Name(name).into()),
-				],
-			));
+			self.push_writenumty(Var::Name(name).into(), numty);
 		}
 	}
-}
 
-impl Ser<'_> {
 	fn push_struct(&mut self, struct_ty: &Struct, from: Var) {
 		for (name, ty) in struct_ty.fields.iter() {
 			self.push_ty(ty, from.clone().eindex(Expr::Str((*name).into())));
@@ -101,7 +97,7 @@ impl Ser<'_> {
 					self.set_bitfield(*bits, var.clone());
 				} else {
 					// make selene happy
-					self.push_stmt(Stmt::Local("_".into(), None));
+					self.buf.push(Stmt::Local("_".into(), None));
 				}
 			}
 			VariantStorageKind::None => {}
@@ -121,17 +117,17 @@ impl Ser<'_> {
 					};
 
 					if i == 0 {
-						self.push_stmt(Stmt::If(from_expr.clone().eq(condition)));
+						self.buf.push(Stmt::If(from_expr.clone().eq(condition)));
 					} else {
-						self.push_stmt(Stmt::ElseIf(from_expr.clone().eq(condition)));
+						self.buf.push(Stmt::ElseIf(from_expr.clone().eq(condition)));
 					}
 
 					self.push_variant_storage(&storage, i);
 				}
 
-				self.push_stmt(Stmt::Else);
-				self.push_stmt(Stmt::Error("Invalid enumerator".into()));
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::Else);
+				self.buf.push(Stmt::Error("Invalid enumerator".into()));
+				self.buf.push(Stmt::End);
 			}
 
 			Enum::Tagged { tag, variants } => {
@@ -140,9 +136,10 @@ impl Ser<'_> {
 
 				for (i, variant) in variants.iter().enumerate() {
 					if i == 0 {
-						self.push_stmt(Stmt::If(tag_expr.clone().eq(Expr::StrOrBool(variant.0.to_string()))));
+						self.buf
+							.push(Stmt::If(tag_expr.clone().eq(Expr::StrOrBool(variant.0.to_string()))));
 					} else {
-						self.push_stmt(Stmt::ElseIf(
+						self.buf.push(Stmt::ElseIf(
 							tag_expr.clone().eq(Expr::StrOrBool(variant.0.to_string())),
 						));
 					}
@@ -151,9 +148,9 @@ impl Ser<'_> {
 					self.push_struct(&variant.1, from.clone());
 				}
 
-				self.push_stmt(Stmt::Else);
-				self.push_stmt(Stmt::Error("Invalid variant".into()));
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::Else);
+				self.buf.push(Stmt::Error("Invalid variant".into()));
+				self.buf.push(Stmt::End);
 			}
 		}
 	}
@@ -161,7 +158,7 @@ impl Ser<'_> {
 	fn push_or(&mut self, from: Var, tys: &Vec<Ty<'_>>, optional: bool) {
 		let (from_ty_name, from_ty_expr) = self.add_occurrence("ty_name");
 
-		self.push_local(
+		self.buf.push_local(
 			from_ty_name,
 			Some(Expr::Call(
 				Box::new(Var::from("typeof")),
@@ -195,10 +192,10 @@ impl Ser<'_> {
 					let condition = from_ty_expr.clone().eq(Expr::Str(name.to_string()));
 
 					if initial_if {
-						self.push_stmt(Stmt::If(condition));
+						self.buf.push(Stmt::If(condition));
 						initial_if = false;
 					} else {
-						self.push_stmt(Stmt::ElseIf(condition));
+						self.buf.push(Stmt::ElseIf(condition));
 					}
 
 					self.push_variant_storage(&storage, i);
@@ -217,10 +214,10 @@ impl Ser<'_> {
 					}
 
 					if initial_if {
-						self.push_stmt(Stmt::If(condition));
+						self.buf.push(Stmt::If(condition));
 						initial_if = false;
 					} else {
-						self.push_stmt(Stmt::ElseIf(condition));
+						self.buf.push(Stmt::ElseIf(condition));
 					}
 
 					self.push_variant_storage(&storage, i);
@@ -236,10 +233,10 @@ impl Ser<'_> {
 						});
 
 						if initial_if {
-							self.push_stmt(Stmt::If(condition));
+							self.buf.push(Stmt::If(condition));
 							initial_if = false;
 						} else {
-							self.push_stmt(Stmt::ElseIf(condition));
+							self.buf.push(Stmt::ElseIf(condition));
 						}
 
 						self.push_variant_storage(&storage, i + offset);
@@ -255,10 +252,10 @@ impl Ser<'_> {
 						);
 
 						if initial_if {
-							self.push_stmt(Stmt::If(condition));
+							self.buf.push(Stmt::If(condition));
 							initial_if = false;
 						} else {
-							self.push_stmt(Stmt::ElseIf(condition));
+							self.buf.push(Stmt::ElseIf(condition));
 						}
 
 						self.push_variant_storage(&storage, i + offset);
@@ -274,22 +271,22 @@ impl Ser<'_> {
 		}
 
 		if optional {
-			self.push_stmt(Stmt::ElseIf(Expr::from(from.clone()).eq(Expr::Nil)));
+			self.buf.push(Stmt::ElseIf(Expr::from(from.clone()).eq(Expr::Nil)));
 			self.push_variant_storage(&storage, i_offset);
 		}
 
-		self.push_stmt(Stmt::Else);
+		self.buf.push(Stmt::Else);
 		if let Some(unknown_i) = unknown_i {
 			self.push_variant_storage(&storage, unknown_i);
 			self.push_ty(&Ty::Unknown, from.clone());
 		} else {
-			self.push_stmt(Stmt::Error("Invalid type".into()));
+			self.buf.push(Stmt::Error("Invalid type".into()));
 		}
-		self.push_stmt(Stmt::End);
+		self.buf.push(Stmt::End);
 	}
 
 	fn set_bitfield(&mut self, bits: BitpackMask, var: Var) {
-		self.push_assign(
+		self.buf.push_assign(
 			var.clone(),
 			Expr::Call(
 				Var::NameIndex(Var::Name("bit32".into()).into(), "bor".into()).into(),
@@ -305,7 +302,7 @@ impl Ser<'_> {
 		match ty {
 			Ty::Num(numty, range) => {
 				if self.checks {
-					self.push_range_check(from_expr.clone(), *range);
+					self.buf.push_range_check(from_expr.clone(), *range);
 				}
 
 				self.push_writenumty(from_expr, *numty)
@@ -314,23 +311,23 @@ impl Ser<'_> {
 			Ty::Str(utf8, range) => {
 				if !utf8 && let Some(len) = range.exact() {
 					if self.checks {
-						self.push_assert(
+						self.buf.push_assert(
 							from_expr.clone().len().eq(len.into()),
 							format!("length is not equal to {len}!"),
 						);
 					}
 
-					self.push_writestring(from_expr, len.into());
+					self.push_writestring(from_expr, range, len.into());
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty();
 
-					self.push_local(len_name.clone(), Some(from_expr.clone().len()));
+					self.buf.push_local(len_name.clone(), Some(from_expr.clone().len()));
 
 					if self.checks {
-						self.push_range_check(len_expr.clone(), *range);
+						self.buf.push_range_check(len_expr.clone(), *range);
 						if *utf8 {
-							self.push_utf8_check(from_expr.clone());
+							self.buf.push_utf8_check(from_expr.clone());
 						}
 					}
 
@@ -340,14 +337,14 @@ impl Ser<'_> {
 					}
 
 					self.push_writenumty(offset_len_expr, len_numty);
-					self.push_writestring(from_expr, len_expr.clone());
+					self.push_writestring(from_expr, range, len_expr.clone());
 				}
 			}
 
 			Ty::Buf(range) => {
 				if let Some(len) = range.exact() {
 					if self.checks {
-						self.push_assert(
+						self.buf.push_assert(
 							Var::from("buffer")
 								.nindex("len")
 								.call(vec![from_expr.clone()])
@@ -356,18 +353,18 @@ impl Ser<'_> {
 						);
 					}
 
-					self.push_write_copy(from_expr, len.into());
+					self.push_write_copy(from_expr, range, len.into());
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty();
 
-					self.push_local(
+					self.buf.push_local(
 						len_name.clone(),
 						Some(Var::from("buffer").nindex("len").call(vec![from_expr.clone()])),
 					);
 
 					if self.checks {
-						self.push_range_check(len_expr.clone(), *range);
+						self.buf.push_range_check(len_expr.clone(), *range);
 					}
 
 					let mut offset_len_expr = len_expr.clone();
@@ -376,14 +373,14 @@ impl Ser<'_> {
 					}
 
 					self.push_writenumty(offset_len_expr, len_numty);
-					self.push_write_copy(from_expr, len_name.as_str().into())
+					self.push_write_copy(from_expr, range, len_name.as_str().into())
 				}
 			}
 
 			Ty::Arr(ty, range) => {
 				if let Some(len) = range.exact() {
 					if self.checks {
-						self.push_assert(
+						self.buf.push_assert(
 							from_expr.clone().len().eq(len.into()),
 							format!("length is not equal to {len}!"),
 						);
@@ -397,10 +394,10 @@ impl Ser<'_> {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty();
 
-					self.push_local(len_name.clone(), Some(from_expr.clone().len()));
+					self.buf.push_local(len_name.clone(), Some(from_expr.clone().len()));
 
 					if self.checks {
-						self.push_range_check(len_expr.clone(), *range);
+						self.buf.push_range_check(len_expr.clone(), *range);
 					}
 
 					let mut offset_len_expr = len_expr.clone();
@@ -410,26 +407,26 @@ impl Ser<'_> {
 
 					self.push_writenumty(offset_len_expr, len_numty);
 
-					self.push_stmt(Stmt::NumFor {
+					self.buf.push(Stmt::NumFor {
 						var: var_name.clone(),
 						from: 1.0.into(),
 						to: len_expr.clone(),
 					});
 
-					self.new_scope();
+					self.new_dyn_scope();
 
 					let (inner_var_name, _) = self.add_occurrence("val");
 
-					self.push_stmt(Stmt::Local(
+					self.buf.push(Stmt::Local(
 						inner_var_name.clone(),
 						Some(from.clone().eindex(var_expr.clone()).into()),
 					));
 
 					self.push_ty(ty, Var::Name(inner_var_name));
 
-					self.end_scope();
+					self.end_dyn_scope();
 
-					self.push_stmt(Stmt::End);
+					self.buf.push(Stmt::End);
 				}
 			}
 
@@ -440,41 +437,45 @@ impl Ser<'_> {
 
 				let length_numty = key.variants().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
-				self.push_local(len_pos_name.clone(), None);
-				self.push_local(len_name.clone(), Some(0.0.into()));
+				self.buf.push_local(len_pos_name.clone(), None);
+				self.buf.push_local(len_name.clone(), Some(0.0.into()));
 
 				let (key_name, _) = self.add_occurrence("k");
 				let (val_name, _) = self.add_occurrence("v");
 
-				self.push_stmt(Stmt::GenFor {
+				self.buf.push(Stmt::GenFor {
 					key: key_name.clone(),
 					val: val_name.clone(),
 					obj: from_expr,
 				});
 
-				self.push_stmt(Stmt::If(len_expr.clone().eq(0.0.into())));
+				self.buf.push(Stmt::If(len_expr.clone().eq(0.0.into())));
 
-				self.push_assign(
+				self.buf.push_assign(
 					Var::Name(len_pos_name.clone()),
 					Var::from("alloc").call(vec![(length_numty.size() as f64).into()]),
 				);
 
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::End);
 
-				self.new_scope();
+				self.new_alloc_scope();
+				self.new_dyn_scope();
 
-				self.push_assign(Var::Name(len_name.clone()), len_expr.clone().add(1.0.into()));
+				self.buf
+					.push_assign(Var::Name(len_name.clone()), len_expr.clone().add(1.0.into()));
 
 				self.push_ty(key, key_name.as_str().into());
 				self.push_ty(val, val_name.as_str().into());
 
-				self.end_scope();
+				self.end_dyn_scope();
+				let alloc = self.end_alloc_scope();
+				alloc.buf.push_alloc((alloc.size as f64).into());
 
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::End);
 
-				self.push_stmt(Stmt::If(len_pos_expr.clone()));
+				self.buf.push(Stmt::If(len_pos_expr.clone()));
 
-				self.push_stmt(Stmt::Call(
+				self.buf.push(Stmt::Call(
 					Var::from("buffer").nindex(format!("write{length_numty}")),
 					None,
 					vec![
@@ -484,11 +485,11 @@ impl Ser<'_> {
 					],
 				));
 
-				self.push_stmt(Stmt::Else);
+				self.buf.push(Stmt::Else);
 
 				self.set_bitfield(empty_bits, empty_var);
 
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::End);
 			}
 
 			Ty::Set(key) => {
@@ -498,39 +499,43 @@ impl Ser<'_> {
 
 				let length_numty = key.variants().map(|(numty, ..)| numty).unwrap_or(NumTy::U16);
 
-				self.push_local(len_pos_name.clone(), None);
-				self.push_local(len_name.clone(), Some(0.0.into()));
+				self.buf.push_local(len_pos_name.clone(), None);
+				self.buf.push_local(len_name.clone(), Some(0.0.into()));
 
 				let (key_name, _) = self.add_occurrence("k");
 				let (val_name, _) = self.add_occurrence("_");
 
-				self.push_stmt(Stmt::GenFor {
+				self.buf.push(Stmt::GenFor {
 					key: key_name.clone(),
 					val: val_name.clone(),
 					obj: from_expr,
 				});
 
-				self.push_stmt(Stmt::If(len_expr.clone().eq(0.0.into())));
+				self.new_alloc_scope();
+				self.new_dyn_scope();
 
-				self.push_assign(
-					Var::Name(len_pos_name.clone()),
-					Var::from("alloc").call(vec![(length_numty.size() as f64).into()]),
-				);
+				self.buf.push(Stmt::If(len_expr.clone().eq(0.0.into())));
 
-				self.push_stmt(Stmt::End);
+				let size = length_numty.size();
+				self.scopes.alloc().max.add(size);
+				self.buf
+					.push_assign(Var::Name(len_pos_name.clone()), alloc((size as f64).into()));
 
-				self.new_scope();
+				self.buf.push(Stmt::End);
 
-				self.push_assign(Var::Name(len_name.clone()), len_expr.clone().add(1.0.into()));
+				self.buf
+					.push_assign(Var::Name(len_name.clone()), len_expr.clone().add(1.0.into()));
 				self.push_ty(key, key_name.as_str().into());
 
-				self.end_scope();
+				self.end_dyn_scope();
+				let alloc = self.end_alloc_scope();
+				alloc.buf.push_alloc((alloc.size as f64).into());
 
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::End);
 
-				self.push_stmt(Stmt::If(len_pos_expr.clone()));
+				self.buf.push(Stmt::If(len_pos_expr.clone()));
 
-				self.push_stmt(Stmt::Call(
+				self.buf.push(Stmt::Call(
 					Var::from("buffer").nindex(format!("write{length_numty}")),
 					None,
 					vec![
@@ -540,11 +545,11 @@ impl Ser<'_> {
 					],
 				));
 
-				self.push_stmt(Stmt::Else);
+				self.buf.push(Stmt::Else);
 
 				self.set_bitfield(empty_bits, empty_var);
 
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::End);
 			}
 
 			Ty::Opt(ty) => {
@@ -552,14 +557,14 @@ impl Ser<'_> {
 					return self.push_or(from, tys, true);
 				}
 
-				self.push_stmt(Stmt::If(from_expr.clone().neq(Expr::Nil)));
+				self.buf.push(Stmt::If(from_expr.clone().neq(Expr::Nil)));
 				let (bits, var) = self.get_bitpack();
 				self.set_bitfield(bits, var);
 				self.push_ty(ty, from);
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::End);
 			}
 
-			Ty::Ref(name, ..) => self.push_stmt(Stmt::Call(
+			Ty::Ref(name, ..) => self.buf.push(Stmt::Call(
 				Var::from("types").nindex(format!("write_{name}")),
 				None,
 				vec![from_expr],
@@ -572,7 +577,7 @@ impl Ser<'_> {
 
 			Ty::Instance(class) => {
 				if self.checks && class.is_some() {
-					self.push_assert(
+					self.buf.push_assert(
 						Expr::Call(
 							Box::new(from),
 							Some("IsA".into()),
@@ -582,14 +587,14 @@ impl Ser<'_> {
 					);
 				}
 
-				self.push_stmt(Stmt::Call(
+				self.buf.push(Stmt::Call(
 					Var::from("table").nindex("insert"),
 					None,
 					vec!["outgoing_inst".into(), from_expr],
 				))
 			}
 
-			Ty::Unknown => self.push_stmt(Stmt::Call(
+			Ty::Unknown => self.buf.push(Stmt::Call(
 				Var::from("table").nindex("insert"),
 				None,
 				vec!["outgoing_inst".into(), from_expr],
@@ -628,7 +633,7 @@ impl Ser<'_> {
 				match **x_ty {
 					Ty::Num(numty, range) => {
 						if self.checks {
-							self.push_range_check(from_expr.clone(), range);
+							self.buf.push_range_check(from_expr.clone(), range);
 						}
 
 						self.push_writenumty(from.clone().nindex("x").into(), numty)
@@ -639,7 +644,7 @@ impl Ser<'_> {
 				match **y_ty {
 					Ty::Num(numty, range) => {
 						if self.checks {
-							self.push_range_check(from_expr.clone(), range);
+							self.buf.push_range_check(from_expr.clone(), range);
 						}
 
 						self.push_writenumty(from.clone().nindex("y").into(), numty)
@@ -651,7 +656,7 @@ impl Ser<'_> {
 					match **z_ty {
 						Ty::Num(numty, range) => {
 							if self.checks {
-								self.push_range_check(from_expr.clone(), range);
+								self.buf.push_range_check(from_expr.clone(), range);
 							}
 
 							self.push_writenumty(from.clone().nindex("z").into(), numty)
@@ -664,7 +669,7 @@ impl Ser<'_> {
 			Ty::AlignedCFrame => {
 				let (axis_alignment_name, axis_alignment_expr) = self.add_occurrence("axis_alignment");
 
-				self.push_local(
+				self.buf.push_local(
 					axis_alignment_name.clone(),
 					Some(Expr::Call(
 						Box::new(Var::from("table").nindex("find")),
@@ -673,7 +678,8 @@ impl Ser<'_> {
 					)),
 				);
 
-				self.push_assert(axis_alignment_expr.clone(), "CFrame not aligned to an axis!".into());
+				self.buf
+					.push_assert(axis_alignment_expr.clone(), "CFrame not aligned to an axis!".into());
 
 				self.push_writeu8(axis_alignment_expr.clone());
 
@@ -684,14 +690,14 @@ impl Ser<'_> {
 				// local axis, angle = Value:ToAxisAngle()
 				let (axis_name, axis_expr) = self.add_occurrence("axis");
 				let (angle_name, angle_expr) = self.add_occurrence("angle");
-				self.push_stmt(Stmt::LocalTuple(
+				self.buf.push(Stmt::LocalTuple(
 					vec![axis_name.clone(), angle_name.clone()],
 					Some(Expr::Call(from.clone().into(), Some("ToAxisAngle".into()), vec![])),
 				));
 
 				// axis = axis * angle
 				// store the angle into the axis, as it is a unit vector, so the magnitude can be used to encode a number
-				self.push_stmt(Stmt::Assign(
+				self.buf.push(Stmt::Assign(
 					Var::Name(axis_name.clone()),
 					Expr::Mul(Box::new(axis_expr), Box::new(angle_expr)),
 				));
@@ -701,10 +707,10 @@ impl Ser<'_> {
 			}
 
 			Ty::Boolean => {
-				self.push_stmt(Stmt::If(from_expr));
+				self.buf.push(Stmt::If(from_expr));
 				let (bits, var) = self.get_bitpack();
 				self.set_bitfield(bits, var);
-				self.push_stmt(Stmt::End);
+				self.buf.push(Stmt::End);
 			}
 		}
 	}
@@ -724,7 +730,7 @@ where
 		checks,
 		buf: OutputBuffer::new(),
 		var_occurrences,
-		scopes: vec![],
+		scopes: Default::default(),
 		typescript_enum_type,
 	}
 	.generate(names, types.into_iter())

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -1,6 +1,6 @@
 use crate::{
 	config::{Enum, NumTy, PrimitiveTy, Struct, Ty, TypeScriptEnumType},
-	irgen::{AllocScope, BitpackMask, DynamicScope, OutputBuffer, Scopes, VariantStorageKind, alloc},
+	irgen::{AllocScope, BitpackMask, DynamicScope, Either, OutputBuffer, Scopes, VariantStorageKind, alloc},
 };
 use std::collections::HashMap;
 
@@ -91,10 +91,16 @@ impl Ser<'_> {
 		}
 	}
 
-	fn push_variant_storage(&mut self, storage: &VariantStorageKind, i: usize) {
+	fn push_variant_storage(&mut self, storage: &VariantStorageKind, i: usize, var: &mut Either<OutputBuffer, Var>) {
 		match storage {
-			VariantStorageKind::Full(numty, _) => {
-				self.push_writenumty((i as f64).into(), *numty);
+			VariantStorageKind::Full(..) => {
+				if let Either::Left(buf) = var {
+					let name = self.add_occurrence("discriminator").0;
+
+					buf.push_local(name.clone(), None);
+					*var = Either::Right(Var::Name(name));
+				}
+				self.buf.push_assign(var.clone().right(), (i as f64).into());
 			}
 			VariantStorageKind::Bitpack(variants) => {
 				let (bits, var) = &variants[i];
@@ -117,6 +123,7 @@ impl Ser<'_> {
 			Enum::Unit(enumerators) => {
 				let from_expr = Expr::from(from.clone());
 				let storage = self.variant_storage(enumerators.len());
+				let mut var = Either::Left(self.buf.insert());
 
 				for (i, enumerator) in enumerators.iter().enumerate() {
 					let condition = match self.typescript_enum_type {
@@ -130,17 +137,24 @@ impl Ser<'_> {
 						self.buf.push(Stmt::ElseIf(from_expr.clone().eq(condition)));
 					}
 
-					self.push_variant_storage(&storage, i);
+					self.push_variant_storage(&storage, i, &mut var);
 				}
 
 				self.buf.push(Stmt::Else);
 				self.buf.push(Stmt::Error("Invalid enumerator".into()));
 				self.buf.push(Stmt::End);
+
+				if let VariantStorageKind::Full(numty, ..) = storage
+					&& let Either::Right(var) = var
+				{
+					self.push_writenumty(var.into(), numty);
+				}
 			}
 
 			Enum::Tagged { tag, variants } => {
 				let tag_expr = Expr::from(from.clone().eindex(Expr::Str((*tag).into())));
 				let storage = self.variant_storage(variants.len());
+				let mut var = Either::Left(self.buf.insert());
 
 				for (i, variant) in variants.iter().enumerate() {
 					if i == 0 {
@@ -152,7 +166,7 @@ impl Ser<'_> {
 						));
 					}
 
-					self.push_variant_storage(&storage, i);
+					self.push_variant_storage(&storage, i, &mut var);
 
 					self.new_alloc_scope();
 					self.push_struct(&variant.1, from.clone());
@@ -162,6 +176,12 @@ impl Ser<'_> {
 				self.buf.push(Stmt::Else);
 				self.buf.push(Stmt::Error("Invalid variant".into()));
 				self.buf.push(Stmt::End);
+
+				if let VariantStorageKind::Full(numty, ..) = storage
+					&& let Either::Right(var) = var
+				{
+					self.push_writenumty(var.into(), numty);
+				}
 			}
 		}
 	}
@@ -192,6 +212,7 @@ impl Ser<'_> {
 		let mut unknown_i = None;
 		let mut initial_if = true;
 		let mut i_offset = 0usize;
+		let mut var = Either::Left(self.buf.insert());
 
 		for ty in tys {
 			let i = i_offset;
@@ -209,7 +230,7 @@ impl Ser<'_> {
 						self.buf.push(Stmt::ElseIf(condition));
 					}
 
-					self.push_variant_storage(&storage, i);
+					self.push_variant_storage(&storage, i, &mut var);
 					self.new_alloc_scope();
 					self.push_ty(ty, from.clone());
 					self.end_alloc_scope();
@@ -233,7 +254,7 @@ impl Ser<'_> {
 						self.buf.push(Stmt::ElseIf(condition));
 					}
 
-					self.push_variant_storage(&storage, i);
+					self.push_variant_storage(&storage, i, &mut var);
 					self.new_alloc_scope();
 					self.push_ty(ty, from.clone());
 					self.end_alloc_scope();
@@ -254,7 +275,7 @@ impl Ser<'_> {
 							self.buf.push(Stmt::ElseIf(condition));
 						}
 
-						self.push_variant_storage(&storage, i + offset);
+						self.push_variant_storage(&storage, i + offset, &mut var);
 					}
 				}
 				PrimitiveTy::Enum(Enum::Tagged { tag, variants }) => {
@@ -273,7 +294,7 @@ impl Ser<'_> {
 							self.buf.push(Stmt::ElseIf(condition));
 						}
 
-						self.push_variant_storage(&storage, i + offset);
+						self.push_variant_storage(&storage, i + offset, &mut var);
 						self.new_alloc_scope();
 						self.push_struct(&data, from.clone());
 						self.end_alloc_scope();
@@ -289,17 +310,23 @@ impl Ser<'_> {
 
 		if optional {
 			self.buf.push(Stmt::ElseIf(Expr::from(from.clone()).eq(Expr::Nil)));
-			self.push_variant_storage(&storage, i_offset);
+			self.push_variant_storage(&storage, i_offset, &mut var);
 		}
 
 		self.buf.push(Stmt::Else);
 		if let Some(unknown_i) = unknown_i {
-			self.push_variant_storage(&storage, unknown_i);
+			self.push_variant_storage(&storage, unknown_i, &mut var);
 			self.push_ty(&Ty::Unknown, from.clone());
 		} else {
 			self.buf.push(Stmt::Error("Invalid type".into()));
 		}
 		self.buf.push(Stmt::End);
+
+		if let VariantStorageKind::Full(numty, ..) = storage
+			&& let Either::Right(var) = var
+		{
+			self.push_writenumty(var.into(), numty);
+		}
 	}
 
 	fn set_bitfield(&mut self, bits: BitpackMask, var: Var) {

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -31,8 +31,7 @@ impl Gen for Ser<'_> {
 		}
 
 		self.end_dyn_scope();
-		let scope = self.end_alloc_scope();
-		scope.buf.push_alloc((scope.size as f64).into());
+		self.end_alloc_scope(None);
 
 		self.buf.output()
 	}
@@ -50,11 +49,21 @@ impl Ser<'_> {
 	fn new_alloc_scope(&mut self) {
 		let scope_buf = OutputBuffer::new();
 		self.buf.push(scope_buf.clone());
-		self.scopes.alloc.push(AllocScope::new(scope_buf));
+		let cursor_name = self.add_occurrence("cursor").0;
+		self.scopes.alloc.push(AllocScope::new(scope_buf, cursor_name));
 	}
 
-	fn end_alloc_scope(&mut self) -> AllocScope {
-		self.scopes.alloc.pop().unwrap()
+	fn end_alloc_scope(&mut self, expr: Option<Expr>) {
+		let mut scope = self.scopes.alloc.pop().unwrap();
+		let size_expr = Expr::Num(scope.size as f64);
+		scope.buf.push_local(
+			scope.cursor_var,
+			Some(alloc(if let Some(expr) = expr {
+				size_expr.mul(expr)
+			} else {
+				size_expr
+			})),
+		);
 	}
 
 	fn new_dyn_scope(&mut self) {
@@ -407,6 +416,8 @@ impl Ser<'_> {
 
 					self.push_writenumty(offset_len_expr, len_numty);
 
+					self.new_alloc_scope();
+
 					self.buf.push(Stmt::NumFor {
 						var: var_name.clone(),
 						from: 1.0.into(),
@@ -425,6 +436,8 @@ impl Ser<'_> {
 					self.push_ty(ty, Var::Name(inner_var_name));
 
 					self.end_dyn_scope();
+
+					self.end_alloc_scope(Some(len_expr));
 
 					self.buf.push(Stmt::End);
 				}
@@ -468,8 +481,7 @@ impl Ser<'_> {
 				self.push_ty(val, val_name.as_str().into());
 
 				self.end_dyn_scope();
-				let alloc = self.end_alloc_scope();
-				alloc.buf.push_alloc((alloc.size as f64).into());
+				self.end_alloc_scope(None);
 
 				self.buf.push(Stmt::End);
 
@@ -528,8 +540,7 @@ impl Ser<'_> {
 				self.push_ty(key, key_name.as_str().into());
 
 				self.end_dyn_scope();
-				let alloc = self.end_alloc_scope();
-				alloc.buf.push_alloc((alloc.size as f64).into());
+				self.end_alloc_scope(None);
 
 				self.buf.push(Stmt::End);
 
@@ -558,9 +569,15 @@ impl Ser<'_> {
 				}
 
 				self.buf.push(Stmt::If(from_expr.clone().neq(Expr::Nil)));
+
+				self.new_alloc_scope();
+
 				let (bits, var) = self.get_bitpack();
 				self.set_bitfield(bits, var);
 				self.push_ty(ty, from);
+
+				self.end_alloc_scope(None);
+
 				self.buf.push(Stmt::End);
 			}
 

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -80,7 +80,8 @@ impl Ser<'_> {
 			let numty = NumTy::from_f64(0.0, ((1u64 << (shift + 1)) - 1) as f64);
 
 			scope.buf.push(Stmt::Local(name.clone(), Some(Expr::Num(0.0))));
-			self.push_writenumty(Var::Name(name).into(), numty);
+			self.push_writenumty_raw(Var::Name(name).into(), numty, true);
+			self.scopes.alloc().offset_by(numty.size());
 		}
 	}
 
@@ -446,17 +447,9 @@ impl Ser<'_> {
 
 					self.end_dyn_scope();
 
-					self.end_alloc_scope_complex(
-						|expr| {
-							expr.mul(len_expr.clone()).add(
-								len_expr
-									.gt(0.0.into())
-									.and((len_numty.size() as f64).into())
-									.or(0.0.into()),
-							)
-						},
-						len_numty.size(),
-					);
+					let scope = self.scopes.alloc();
+					scope.offset_expr(var_expr.clone().sub(1.0.into()).mul((scope.size as f64).into()));
+					self.end_alloc_scope_complex(|expr| expr.mul(len_expr), 0);
 
 					self.buf.push(Stmt::End);
 				}

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -31,7 +31,7 @@ impl Gen for Ser<'_> {
 		}
 
 		self.end_dyn_scope();
-		self.end_alloc_scope(None);
+		self.end_alloc_scope();
 
 		self.buf.output()
 	}
@@ -53,17 +53,15 @@ impl Ser<'_> {
 		self.scopes.alloc.push(AllocScope::new(scope_buf, cursor_name));
 	}
 
-	fn end_alloc_scope(&mut self, expr: Option<Expr>) {
+	fn end_alloc_scope(&mut self) {
+		self.end_alloc_scope_complex(|e| e, 0);
+	}
+
+	fn end_alloc_scope_complex(&mut self, cb: impl FnOnce(Expr) -> Expr, offset: usize) {
 		let mut scope = self.scopes.alloc.pop().unwrap();
+		scope.offset_by(offset);
 		let size_expr = Expr::Num(scope.size as f64);
-		scope.buf.push_local(
-			scope.cursor_var,
-			Some(alloc(if let Some(expr) = expr {
-				size_expr.mul(expr)
-			} else {
-				size_expr
-			})),
-		);
+		scope.buf.push_local(scope.cursor_var, Some(alloc(cb(size_expr))));
 	}
 
 	fn new_dyn_scope(&mut self) {
@@ -154,7 +152,10 @@ impl Ser<'_> {
 					}
 
 					self.push_variant_storage(&storage, i);
+
+					self.new_alloc_scope();
 					self.push_struct(&variant.1, from.clone());
+					self.end_alloc_scope();
 				}
 
 				self.buf.push(Stmt::Else);
@@ -208,7 +209,9 @@ impl Ser<'_> {
 					}
 
 					self.push_variant_storage(&storage, i);
+					self.new_alloc_scope();
 					self.push_ty(ty, from.clone());
+					self.end_alloc_scope();
 				}
 				PrimitiveTy::Instance(class) => {
 					i_offset += 1;
@@ -230,7 +233,9 @@ impl Ser<'_> {
 					}
 
 					self.push_variant_storage(&storage, i);
+					self.new_alloc_scope();
 					self.push_ty(ty, from.clone());
+					self.end_alloc_scope();
 				}
 				PrimitiveTy::Enum(Enum::Unit(variants)) => {
 					i_offset += variants.len();
@@ -268,7 +273,9 @@ impl Ser<'_> {
 						}
 
 						self.push_variant_storage(&storage, i + offset);
+						self.new_alloc_scope();
 						self.push_struct(&data, from.clone());
+						self.end_alloc_scope();
 					}
 				}
 				PrimitiveTy::Unknown => {
@@ -287,7 +294,9 @@ impl Ser<'_> {
 		self.buf.push(Stmt::Else);
 		if let Some(unknown_i) = unknown_i {
 			self.push_variant_storage(&storage, unknown_i);
+			self.new_alloc_scope();
 			self.push_ty(&Ty::Unknown, from.clone());
+			self.end_alloc_scope();
 		} else {
 			self.buf.push(Stmt::Error("Invalid type".into()));
 		}
@@ -437,7 +446,17 @@ impl Ser<'_> {
 
 					self.end_dyn_scope();
 
-					self.end_alloc_scope(Some(len_expr));
+					self.end_alloc_scope_complex(
+						|expr| {
+							expr.mul(len_expr.clone()).add(
+								len_expr
+									.gt(0.0.into())
+									.and((len_numty.size() as f64).into())
+									.or(0.0.into()),
+							)
+						},
+						len_numty.size(),
+					);
 
 					self.buf.push(Stmt::End);
 				}
@@ -466,22 +485,22 @@ impl Ser<'_> {
 
 				self.buf.push_assign(
 					Var::Name(len_pos_name.clone()),
-					Var::from("alloc").call(vec![(length_numty.size() as f64).into()]),
+					alloc((length_numty.size() as f64).into()),
 				);
 
 				self.buf.push(Stmt::End);
 
-				self.new_alloc_scope();
-				self.new_dyn_scope();
-
 				self.buf
 					.push_assign(Var::Name(len_name.clone()), len_expr.clone().add(1.0.into()));
+
+				self.new_alloc_scope();
+				self.new_dyn_scope();
 
 				self.push_ty(key, key_name.as_str().into());
 				self.push_ty(val, val_name.as_str().into());
 
 				self.end_dyn_scope();
-				self.end_alloc_scope(None);
+				self.end_alloc_scope();
 
 				self.buf.push(Stmt::End);
 
@@ -523,9 +542,6 @@ impl Ser<'_> {
 					obj: from_expr,
 				});
 
-				self.new_alloc_scope();
-				self.new_dyn_scope();
-
 				self.buf.push(Stmt::If(len_expr.clone().eq(0.0.into())));
 
 				let size = length_numty.size();
@@ -535,12 +551,15 @@ impl Ser<'_> {
 
 				self.buf.push(Stmt::End);
 
+				self.new_alloc_scope();
+				self.new_dyn_scope();
+
 				self.buf
 					.push_assign(Var::Name(len_name.clone()), len_expr.clone().add(1.0.into()));
 				self.push_ty(key, key_name.as_str().into());
 
 				self.end_dyn_scope();
-				self.end_alloc_scope(None);
+				self.end_alloc_scope();
 
 				self.buf.push(Stmt::End);
 
@@ -576,7 +595,7 @@ impl Ser<'_> {
 				self.set_bitfield(bits, var);
 				self.push_ty(ty, from);
 
-				self.end_alloc_scope(None);
+				self.end_alloc_scope();
 
 				self.buf.push(Stmt::End);
 			}

--- a/zap/src/output/luau/base.luau
+++ b/zap/src/output/luau/base.luau
@@ -45,7 +45,7 @@ local CFrameSpecialCases = {
 local function alloc(len: number)
 	if outgoing_used + len > outgoing_size then
 		while outgoing_used + len > outgoing_size do
-			outgoing_size = outgoing_size * 2
+			outgoing_size = outgoing_size * 1.5
 		end
 
 		local new_buff = buffer.create(outgoing_size)

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::config::{
 	Casing, Config, Enum, EvCall, EvDecl, EvSource, EvType, FnDecl, NamespaceEntry, NonPrimitiveTy, NumTy, Parameter,
-	PrimitiveTy, Range, Struct, Ty, TyDecl, TypeScriptEnumType, UNRELIABLE_ORDER_NUMTY, YieldType,
+	PrimitiveTy, Range, Struct, Ty, TyDecl, TypeScriptEnumType, YieldType,
 };
 
 use super::{
@@ -595,39 +595,16 @@ impl<'src> Converter<'src> {
 				.collect::<Vec<_>>()
 		});
 
-		if data.is_some() && matches!(evty, EvType::Unreliable(_)) {
-			let start_size = match evty {
-				EvType::Unreliable(true) => UNRELIABLE_ORDER_NUMTY.size(),
-				_ => 0,
-			};
-			let mut min = start_size;
-			let mut max = Some(start_size);
+		// if let Some(data) = &data
+		// 	&& matches!(evty, EvType::Unreliable(_))
+		// {
+		// 	let start_size = match evty {
+		// 		EvType::Unreliable(true) => UNRELIABLE_ORDER_NUMTY.size(),
+		// 		_ => 0,
+		// 	};
 
-			for parameter in data.as_ref().unwrap() {
-				let (ty_min, ty_max) = parameter.ty.size(&mut HashSet::new());
-
-				min += ty_min;
-
-				if let (Some(ty_max), Some(max)) = (ty_max, max.as_mut()) {
-					*max += ty_max;
-				} else {
-					max = None;
-				}
-			}
-
-			if min > MAX_UNRELIABLE_SIZE {
-				self.report(Report::AnalyzeOversizeUnreliable {
-					ev_span: evdecl.span(),
-					ty_span: evdecl.data.as_ref().unwrap().span(),
-					size: min,
-				});
-			} else if max.is_none_or(|max| max >= MAX_UNRELIABLE_SIZE) {
-				self.report(Report::AnalyzePotentiallyOversizeUnreliable {
-					ev_span: evdecl.span(),
-					ty_span: evdecl.data.as_ref().unwrap().span(),
-				});
-			}
-		}
+		// 	crate::irgen::ser::generate(data.iter().map(|param| &param.ty), data.iter().map(|param| param.name))
+		// }
 
 		EvDecl {
 			name,
@@ -637,6 +614,7 @@ impl<'src> Converter<'src> {
 			data: data.unwrap_or_default(),
 			id,
 			path: self.path.clone(),
+			serde: None,
 		}
 	}
 


### PR DESCRIPTION
This will: help resolve mismatches between serde and the size, simplify representation of the new features such as bitpacking, and allow us to combine alloc calls into one where possible ahead of time.