### PR TITLE
Refactor type resolution

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -184,6 +184,10 @@
 
     "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
 
+    "@types/node": ["@types/node@24.2.1", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ=="],
+
+    "@types/react": ["@types/react@19.1.9", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/web-bluetooth": ["@types/web-bluetooth@0.0.20", "", {}, "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow=="],
@@ -337,6 +341,8 @@
     "tabbable": ["tabbable@6.2.0", "", {}, "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
 
     "unist-util-is": ["unist-util-is@6.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw=="],
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,4 @@
 {
-  "type": "module",
-  "scripts": {
-    "predocs:dev": "bun wasm:build",
-    "docs:dev": "vitepress dev docs",
-    "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs",
-    "wasm:build": "wasm-pack build zap -d package"
-  },
   "devDependencies": {
     "@guolao/vue-monaco-editor": "1.5.5",
     "ansi-to-vue3": "0.1.2",
@@ -15,5 +7,13 @@
     "vitepress": "1.6.3",
     "vitepress-plugin-tabs": "0.7.0",
     "vue": "3.5.13"
-  }
+  },
+  "scripts": {
+    "predocs:dev": "bun wasm:build",
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs",
+    "wasm:build": "wasm-pack build zap -d package"
+  },
+  "type": "module"
 }

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -273,7 +273,7 @@ impl Display for TyDecl<'_> {
 			return write!(f, "{}", self.name);
 		}
 
-		write!(f, "__ZAP_NAMESPACE__{}_{}", self.path.join("_"), self.name)
+		write!(f, "{}_{}", self.path.join("_"), self.name)
 	}
 }
 
@@ -332,8 +332,17 @@ impl<'src> Ty<'src> {
 			Self::Num(numty, ..) => (numty.size(), Some(numty.size())),
 
 			Self::Str(utf8, len) => {
-				if !utf8 && let Some(exact) = len.exact() {
-					(exact as usize, Some(exact as usize))
+				if !utf8 {
+					if let Some(exact) = len.exact() {
+						(exact as usize, Some(exact as usize))
+					} else {
+						let (len_numty, ..) = len.numty();
+
+						(
+							len.min().map(|min| min as usize).unwrap_or(0) + len_numty.size(),
+							len.max().map(|max| max as usize + len_numty.size()),
+						)
+					}
 				} else {
 					let (len_numty, ..) = len.numty();
 

--- a/zap/src/irgen/des.rs
+++ b/zap/src/irgen/des.rs
@@ -233,8 +233,30 @@ impl Des<'_> {
 			}
 
 			Ty::Str(utf8, range) => {
-				if !utf8 && let Some(len) = range.exact() {
-					self.push_assign(into, self.readstring(len.into()));
+				if !utf8 {
+					if let Some(len) = range.exact() {
+						self.push_assign(into, self.readstring(len.into()));
+					} else {
+						let (len_name, len_expr) = self.add_occurrence("len");
+						let (len_numty, len_offset) = range.numty();
+
+						let mut offset_len_expr = self.readnumty(len_numty);
+						if len_offset != 0.0 {
+							offset_len_expr = offset_len_expr.add(Expr::Num(len_offset))
+						}
+
+						self.push_local(len_name.clone(), Some(offset_len_expr));
+
+						if self.checks {
+							self.push_range_check(len_expr.clone(), *range);
+						}
+
+						self.push_assign(into.clone(), self.readstring(len_expr.clone()));
+
+						if *utf8 {
+							self.push_utf8_check(Expr::Var(into.into()));
+						}
+					}
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty();

--- a/zap/src/irgen/ser.rs
+++ b/zap/src/irgen/ser.rs
@@ -312,15 +312,37 @@ impl Ser<'_> {
 			}
 
 			Ty::Str(utf8, range) => {
-				if !utf8 && let Some(len) = range.exact() {
-					if self.checks {
-						self.push_assert(
-							from_expr.clone().len().eq(len.into()),
-							format!("length is not equal to {len}!"),
-						);
-					}
+				if !utf8 {
+					if let Some(len) = range.exact() {
+						if self.checks {
+							self.push_assert(
+								from_expr.clone().len().eq(len.into()),
+								format!("length is not equal to {len}!"),
+							);
+						}
 
-					self.push_writestring(from_expr, len.into());
+						self.push_writestring(from_expr, len.into());
+					} else {
+						let (len_name, len_expr) = self.add_occurrence("len");
+						let (len_numty, len_offset) = range.numty();
+
+						self.push_local(len_name.clone(), Some(from_expr.clone().len()));
+
+						if self.checks {
+							self.push_range_check(len_expr.clone(), *range);
+							if *utf8 {
+								self.push_utf8_check(from_expr.clone());
+							}
+						}
+
+						let mut offset_len_expr = len_expr.clone();
+						if len_offset != 0.0 {
+							offset_len_expr = offset_len_expr.sub(Expr::Num(len_offset))
+						}
+
+						self.push_writenumty(offset_len_expr, len_numty);
+						self.push_writestring(from_expr, len_expr.clone());
+					}
 				} else {
 					let (len_name, len_expr) = self.add_occurrence("len");
 					let (len_numty, len_offset) = range.numty();

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -160,9 +160,7 @@ impl<'src> ClientOutput<'src> {
 		let ty = &*tydecl.ty.borrow();
 
 		self.push_indent();
-		if tydecl.path.is_empty() {
-			self.push("export ");
-		}
+		self.push("export ");
 		self.push(&format!("type {tydecl} = "));
 		self.push_ty(ty);
 		self.push("\n");

--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -146,9 +146,7 @@ impl<'src> ServerOutput<'src> {
 		let ty = &*tydecl.ty.borrow();
 
 		self.push_indent();
-		if tydecl.path.is_empty() {
-			self.push("export ");
-		}
+		self.push("export ");
 		self.push(&format!("type {tydecl} = "));
 		self.push_ty(ty);
 		self.push("\n");

--- a/zap/src/output/luau/types.rs
+++ b/zap/src/output/luau/types.rs
@@ -46,9 +46,7 @@ impl<'src> TypesOutput<'src> {
 		let ty = &*tydecl.ty.borrow();
 
 		self.push_indent();
-		if tydecl.path.is_empty() {
-			self.push("export ");
-		}
+		self.push("export ");
 		self.push(&format!("type {tydecl} = "));
 		self.push_ty(ty);
 		self.push("\n");

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -87,30 +87,49 @@ impl<'src> Converter<'src> {
 			}
 		}
 
+		// First pass: collect ALL type declarations from all namespaces
+		for (decls, path) in nsdecls.iter().rev() {
+			let current_tydecls = decls.iter().filter_map(|decl| match decl {
+				SyntaxDecl::Ty(tydecl) => Some(tydecl),
+				_ => None,
+			});
+
+			for tydecl in current_tydecls {
+				let key = path
+					.iter()
+					.copied()
+					.chain(std::iter::once(tydecl.name.name))
+					.collect::<Vec<_>>()
+					.join(".");
+				self.tydecls.insert(key, tydecl.clone());
+			}
+		}
+		
+		// Also collect global types
+		let global_tydecls = config.decls.iter().filter_map(|decl| match decl {
+			SyntaxDecl::Ty(tydecl) => Some(tydecl),
+			_ => None,
+		});
+
+		for tydecl in global_tydecls {
+			let key = tydecl.name.name.to_string();
+			self.tydecls.insert(key, tydecl.clone());
+		}
+		
+		// Second pass: process type declarations (now all types are available for resolution)
 		for (decls, path) in nsdecls
 			.into_iter()
 			// reverse so namespaces higher can use types from namespaces lower
 			.rev()
 			.chain(std::iter::once((&config.decls, vec![])))
 		{
-			self.path = path;
+			self.path = path.clone();
+			
 
 			let current_tydecls = decls.iter().filter_map(|decl| match decl {
 				SyntaxDecl::Ty(tydecl) => Some(tydecl),
 				_ => None,
 			});
-
-			for tydecl in current_tydecls.clone() {
-				self.tydecls.insert(
-					self.path
-						.iter()
-						.copied()
-						.chain(std::iter::once(tydecl.name.name))
-						.collect::<Vec<_>>()
-						.join("."),
-					tydecl.clone(),
-				);
-			}
 
 			for tydecl in current_tydecls {
 				let tydecl = self.tydecl(tydecl);
@@ -874,15 +893,7 @@ impl<'src> Converter<'src> {
 				"unknown" => Ty::Opt(Box::new(Ty::Unknown)),
 
 				_ => {
-					let path = self
-						.path
-						.iter()
-						.copied()
-						.chain(std::iter::once(ref_ty.name))
-						.collect::<Vec<_>>()
-						.join(".");
-
-					let Some(tydecl) = self.tydecls.get(&path).cloned() else {
+					let Some(tydecl) = self.resolve_type_reference(ref_ty.name) else {
 						self.report(Report::AnalyzeUnknownTypeRef {
 							span: ref_ty.span(),
 							name: Cow::Borrowed(ref_ty.name),
@@ -1100,23 +1111,17 @@ impl<'src> Converter<'src> {
 			}
 
 			SyntaxTyKind::Ref(ref_ty) => {
-				let key = self
-					.path
-					.iter()
-					.copied()
-					.chain(std::iter::once(ref_ty.name))
-					.collect::<Vec<_>>()
-					.join(".");
+				let Some((key, tydecl)) = self.resolve_type_reference_with_path(ref_ty.name) else {
+					return TyRecursionKind::None;
+				};
 
 				if key == target_path {
 					TyRecursionKind::Unbounded(*ref_ty)
 				} else if searched.contains(&key) {
 					TyRecursionKind::None
-				} else if let Some(tydecl) = self.tydecls.get(&key) {
+				} else {
 					searched.insert(key);
 					self.ty_recursion_kind(target_path, &tydecl.ty, searched)
-				} else {
-					TyRecursionKind::None
 				}
 			}
 
@@ -1288,6 +1293,54 @@ impl<'src> Converter<'src> {
 	fn num(&self, num: &SyntaxNumLit<'src>) -> f64 {
 		// unwrapping here is safe because the parser already validated the number earlier
 		num.value.parse().unwrap()
+	}
+
+	fn resolve_type_reference(&self, type_name: &str) -> Option<SyntaxTyDecl<'src>> {
+		// First try current namespace path (local scope takes precedence)
+		let namespaced_path = self
+			.path
+			.iter()
+			.copied()
+			.chain(std::iter::once(type_name))
+			.collect::<Vec<_>>()
+			.join(".");
+		
+		if let Some(tydecl) = self.tydecls.get(&namespaced_path) {
+			return Some(tydecl.clone());
+		}
+		
+		// If not found and we're in a namespace, try global scope as fallback
+		if !self.path.is_empty() {
+			if let Some(tydecl) = self.tydecls.get(type_name) {
+				return Some(tydecl.clone());
+			}
+		}
+		
+		None
+	}
+
+	fn resolve_type_reference_with_path(&self, type_name: &str) -> Option<(String, SyntaxTyDecl<'src>)> {
+		// First try current namespace path
+		let namespaced_path = self
+			.path
+			.iter()
+			.copied()
+			.chain(std::iter::once(type_name))
+			.collect::<Vec<_>>()
+			.join(".");
+		
+		if let Some(tydecl) = self.tydecls.get(&namespaced_path) {
+			return Some((namespaced_path, tydecl.clone()));
+		}
+		
+		// If not found and we're in a namespace, try global scope
+		if !self.path.is_empty() {
+			if let Some(tydecl) = self.tydecls.get(type_name) {
+				return Some((type_name.to_string(), tydecl.clone()));
+			}
+		}
+		
+		None
 	}
 }
 


### PR DESCRIPTION
Basically, I've just added support to allow Zap to export namespace types as well as use global types.

```zap
type GamePasses = enum {Vip, King}

namespace ProblemWithNamespace = {
	event OnPurchaseGamePass = {
		from: Server,
		type: Reliable,
		call: SingleAsync,
		data: (gamePass: GamePasses),
	}
}

namespace ThisShouldNotBreakEither = {
	type GamePasses = enum {LocalVip}
	event OnPurchaseGamePass = {
		from: Server,
		type: Reliable,
		call: SingleAsync,
		data: (gamePass: GamePasses),
	}
}
```

This works properly now!

Sorry if I undid any things, I had to remove some stuff to enable building properly.