### PR TITLE
Add `include_profile_labels` option to include microprofiler labels

### DIFF
--- a/docs/.vitepress/components/Editor.vue
+++ b/docs/.vitepress/components/Editor.vue
@@ -2,13 +2,13 @@
 	<MonacoEditor
 		:value="props.modelValue"
 		@update:value="(val: string) => $emit('update:modelValue', val)"
-		:language="lang ?? 'zapConfig'"  
+		:language="lang ?? 'zapConfig'"
 		:theme="`${props.isCodeBlock ? 'codeblock' : 'tab'}-${isDark ? 'dark' : 'light'}`"
 		@beforeMount="beforeMount"
 		@mount="(editor) => $emit('mounted', editor)"
 		:options="EDITOR_OPTIONS"
-	/>	
-</template>	
+	/>
+</template>
 
 <script setup lang="ts">
 import MonacoEditor from "@guolao/vue-monaco-editor";
@@ -110,7 +110,7 @@ const beforeMount = (monaco: Monaco) => {
 
 	const Calls = ["SingleSync", "SingleAsync", "ManySync", "ManyAsync", "Polling"] as const;
 
-	const Options = ["write_checks", "typescript", "typescript_max_tuple_length", "typescript_enum", "manual_event_loop", "remote_scope", "remote_folder", "server_output", "client_output", "casing", "yield_type", "async_lib", "tooling", "tooling_output", "tooling_show_internal_data", "disable_fire_all", "types_output", "call_default"] as const;
+	const Options = ["write_checks", "typescript", "typescript_max_tuple_length", "typescript_enum", "manual_event_loop", "include_profile_labels", "remote_scope", "remote_folder", "server_output", "client_output", "casing", "yield_type", "async_lib", "tooling", "tooling_output", "tooling_show_internal_data", "disable_fire_all", "types_output", "call_default"] as const;
 
 	const TypeScriptEnum = ["StringLiteral", "ConstEnum", "StringConstEnum"].map((value) => `"${value}"`)
 	const Casing = ["PascalCase", "camelCase", "snake_case"].map((value) => `"${value}"`);
@@ -167,6 +167,7 @@ const beforeMount = (monaco: Monaco) => {
 
 		write_checks: Operators,
 		manual_event_loop: Operators,
+		include_profile_labels: Operators,
 
 		remote_scope: [],
 		remote_folder: [],

--- a/docs/config/options.md
+++ b/docs/config/options.md
@@ -217,6 +217,23 @@ Note that Zap uses `RunService.Heartbeat` and a 61 hz rate by default.
 
 <CodeBlock code="opt manual_event_loop = true" />
 
+## `include_profile_labels`
+
+When enabled, microprofiler lables are added to the generated file to diagnose performance issues.
+
+### Default
+
+`false`
+
+### Options
+
+- `true`
+- `false`
+
+### Example
+
+<CodeBlock code="opt include_profile_labels = true" />
+
 ## `typescript_max_tuple_length`
 
 The maximum non-nested length of tuples Zap can generate, with anything longer generating an array.

--- a/polyfill.yml
+++ b/polyfill.yml
@@ -37,6 +37,11 @@ globals:
     - type: any
     - required: false
       type: '...'
+  debug.profilebegin:
+    args:
+      - type: string
+  debug.profileend:
+    args: []
 structs:
   DataModel:
     GetService:

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -38,6 +38,7 @@ pub struct Config<'src> {
 
 	pub write_checks: bool,
 	pub manual_event_loop: bool,
+	pub include_profile_labels: bool,
 
 	pub remote_scope: &'src str,
 	pub remote_folder: &'src str,

--- a/zap/src/config.rs
+++ b/zap/src/config.rs
@@ -216,6 +216,16 @@ pub struct FnDecl<'src> {
 	pub path: Vec<&'src str>,
 }
 
+impl<'src> FnDecl<'src> {
+	pub fn display_path(&self) -> String {
+		if self.path.is_empty() {
+			self.name.to_string()
+		} else {
+			format!("{}.{}", self.path.join("."), self.name)
+		}
+	}
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FnCall {
 	Async,
@@ -231,6 +241,16 @@ pub struct EvDecl<'src> {
 	pub data: Vec<Parameter<'src>>,
 	pub id: usize,
 	pub path: Vec<&'src str>,
+}
+
+impl<'src> EvDecl<'src> {
+	pub fn display_path(&self) -> String {
+		if self.path.is_empty() {
+			self.name.to_string()
+		} else {
+			format!("{}.{}", self.path.join("."), self.name)
+		}
+	}
 }
 
 #[derive(Debug, Clone)]

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -123,7 +123,10 @@ impl<'src> ClientOutput<'src> {
 								this.indent();
 								this.push_line("return Future.new(function()");
 								this.indent();
-								this.push_line(&format!("error(\"{} called when game is not running\")", fndecl.name));
+								this.push_line(&format!(
+									"error(\"{} called when game is not running\")",
+									fndecl.display_path()
+								));
 								this.dedent();
 								this.push_line("end)");
 								this.dedent();
@@ -134,7 +137,7 @@ impl<'src> ClientOutput<'src> {
 								this.indent();
 								this.push_line(&format!(
 									"return Promise.reject(\"{} called when game is not running\")",
-									fndecl.name
+									fndecl.display_path()
 								));
 								this.dedent();
 								this.push_line("end");
@@ -395,7 +398,7 @@ impl<'src> ClientOutput<'src> {
 		self.indent();
 
 		if self.config.include_profile_labels {
-			self.push_line(&format!("debug.profilebegin(\"{} Deserialize\")", ev.name));
+			self.push_line(&format!("debug.profilebegin(\"{} Deserialize\")", ev.display_path()));
 		}
 
 		let values = self.get_values(ev.data.len());
@@ -430,12 +433,20 @@ impl<'src> ClientOutput<'src> {
 			self.indent();
 		}
 
+		if self.config.include_profile_labels && ev.call != EvCall::Polling {
+			self.push_line(&format!("debug.profilebegin(\"{} Callback\")", ev.display_path()));
+		}
+
 		match ev.call {
 			EvCall::SingleSync => self.push_line(&format!("reliable_events[{id}]({values})")),
 			EvCall::SingleAsync => self.push_line(&format!("task.spawn(reliable_events[{id}], {values})")),
 			EvCall::ManySync => self.push_line(&format!("cb({values})")),
 			EvCall::ManyAsync => self.push_line(&format!("task.spawn(cb, {values})")),
 			EvCall::Polling => (),
+		}
+
+		if self.config.include_profile_labels && ev.call != EvCall::Polling {
+			self.push_line("debug.profileend()");
 		}
 
 		if ev.call == EvCall::ManySync || ev.call == EvCall::ManyAsync {
@@ -473,7 +484,7 @@ impl<'src> ClientOutput<'src> {
 
 			self.push(&format!(
 				"reliable_event_queue[{id}]}} events in queue for {}. Did you forget to attach a listener?`)\n",
-				ev.name
+				ev.display_path()
 			));
 
 			self.dedent();
@@ -506,7 +517,10 @@ impl<'src> ClientOutput<'src> {
 		self.indent();
 
 		if self.config.include_profile_labels {
-			self.push_line(&format!("debug.profilebegin(\"{} Deserialize\")", fndecl.name));
+			self.push_line(&format!(
+				"debug.profilebegin(\"{} Deserialize\")",
+				fndecl.display_path()
+			));
 		}
 
 		self.push_line("local call_id = buffer.readu8(incoming_buff, read(1))");
@@ -625,7 +639,10 @@ impl<'src> ClientOutput<'src> {
 		self.indent();
 
 		if self.config.include_profile_labels {
-			self.push_line(&format!("debug.profilebegin(\"Zap {} OnClientEvent\")", ev.name));
+			self.push_line(&format!(
+				"debug.profilebegin(\"Zap {} OnClientEvent\")",
+				ev.display_path()
+			));
 		}
 
 		self.push_line("incoming_buff = buff");
@@ -681,12 +698,20 @@ impl<'src> ClientOutput<'src> {
 				self.indent();
 			}
 
+			if self.config.include_profile_labels {
+				self.push_line(&format!("debug.profilebegin(\"{} Callback\")", ev.display_path()));
+			}
+
 			match ev.call {
 				EvCall::SingleSync => self.push_line(&format!("unreliable_events[{id}]({values})")),
 				EvCall::SingleAsync => self.push_line(&format!("task.spawn(unreliable_events[{id}], {values})")),
 				EvCall::ManySync => self.push_line(&format!("cb({values})")),
 				EvCall::ManyAsync => self.push_line(&format!("task.spawn(cb, {values})")),
 				EvCall::Polling => (),
+			}
+
+			if self.config.include_profile_labels {
+				self.push_line("debug.profileend()");
 			}
 
 			if ev.call == EvCall::ManySync || ev.call == EvCall::ManyAsync {
@@ -722,7 +747,7 @@ impl<'src> ClientOutput<'src> {
 
 			self.push(&format!(
 				"unreliable_event_queue[{id}]}} events in queue for {}. Did you forget to attach a listener?`)\n",
-				ev.name
+				ev.display_path()
 			));
 
 			self.dedent();
@@ -860,7 +885,7 @@ impl<'src> ClientOutput<'src> {
 		self.indent();
 
 		if self.config.include_profile_labels {
-			self.push_line(&format!("debug.profilebegin(\"{} Fire\")", ev.name));
+			self.push_line(&format!("debug.profilebegin(\"{} Fire\")", ev.display_path()));
 		}
 
 		if let EvType::Unreliable(ordered) = ev.evty {
@@ -934,13 +959,6 @@ impl<'src> ClientOutput<'src> {
 		self.push(") -> ()): () -> ()\n");
 		self.indent();
 
-		if self.config.include_profile_labels {
-			self.push_line(&format!(
-				"{callback} = profiledCallback(\"{} Callback\", {callback})",
-				ev.name
-			));
-		}
-
 		self.push_line(&format!("{}[{id}] = {callback}", events_table_name(ev)));
 
 		let event_queue_name = event_queue_table_name(ev);
@@ -949,16 +967,24 @@ impl<'src> ClientOutput<'src> {
 			self.push_line(&format!("for _, value in {event_queue_name}[{id}] do"));
 			self.indent();
 
+			if self.config.include_profile_labels {
+				self.push_line(&format!("debug.profilebegin(\"{} Callback\")", ev.display_path()));
+			}
+
+			self.push_indent();
+
 			if ev.call == EvCall::SingleSync {
-				self.push_indent();
 				self.push(&format!("{callback}("));
 				self.push_queued_value(&ev.data);
 				self.push_line(")\n");
 			} else {
-				self.push_indent();
 				self.push(&format!("task.spawn({callback}, "));
 				self.push_queued_value(&ev.data);
 				self.push(")\n");
+			}
+
+			if self.config.include_profile_labels {
+				self.push_line("debug.profileend()");
 			}
 
 			self.dedent();
@@ -969,10 +995,18 @@ impl<'src> ClientOutput<'src> {
 			self.push_line(&format!("for _ = 1, {event_queue_name}[{id}] do"));
 			self.indent();
 
+			if self.config.include_profile_labels {
+				self.push_line(&format!("debug.profilebegin(\"{} Callback\")", ev.display_path()));
+			}
+
 			if ev.call == EvCall::SingleSync {
-				self.push_line(&format!("{callback}()"))
+				self.push_line(&format!("{callback}()"));
 			} else {
-				self.push_line(&format!("task.spawn({callback})"))
+				self.push_line(&format!("task.spawn({callback})"));
+			}
+
+			if self.config.include_profile_labels {
+				self.push_line("debug.profileend()");
 			}
 
 			self.dedent();
@@ -1009,13 +1043,6 @@ impl<'src> ClientOutput<'src> {
 		self.push(") -> ())\n");
 		self.indent();
 
-		if self.config.include_profile_labels {
-			self.push_line(&format!(
-				"{callback} = profiledCallback(\"{} Callback\", {callback})",
-				ev.name
-			));
-		}
-
 		let events_table_name = events_table_name(ev);
 		let event_queue_name = event_queue_table_name(ev);
 
@@ -1025,16 +1052,24 @@ impl<'src> ClientOutput<'src> {
 			self.push_line(&format!("for _, value in {event_queue_name}[{id}] do"));
 			self.indent();
 
+			if self.config.include_profile_labels {
+				self.push_line(&format!("debug.profilebegin(\"{} Callback\")", ev.display_path()));
+			}
+
+			self.push_indent();
+
 			if ev.call == EvCall::ManySync {
-				self.push_indent();
 				self.push(&format!("{callback}("));
 				self.push_queued_value(&ev.data);
 				self.push_line(")\n");
 			} else {
-				self.push_indent();
 				self.push(&format!("task.spawn({callback}, "));
 				self.push_queued_value(&ev.data);
 				self.push(")\n");
+			}
+
+			if self.config.include_profile_labels {
+				self.push_line("debug.profileend()");
 			}
 
 			self.dedent();
@@ -1045,10 +1080,18 @@ impl<'src> ClientOutput<'src> {
 			self.push_line(&format!("for _ = 1, {event_queue_name}[{id}] do"));
 			self.indent();
 
+			if self.config.include_profile_labels {
+				self.push_line(&format!("debug.profilebegin(\"{} Callback\")", ev.display_path()));
+			}
+
 			if ev.call == EvCall::ManySync {
 				self.push_line(&format!("{callback}()"))
 			} else {
 				self.push_line(&format!("task.spawn({callback})"))
+			}
+
+			if self.config.include_profile_labels {
+				self.push_line("debug.profileend()");
 			}
 
 			self.dedent();
@@ -1270,7 +1313,7 @@ impl<'src> ClientOutput<'src> {
 						this.indent();
 
 						if self.config.include_profile_labels {
-							this.push_line(&format!("debug.profilebegin(\"{} Call\")", fndecl.name));
+							this.push_line(&format!("debug.profilebegin(\"{} Call\")", fndecl.display_path()));
 						}
 
 						this.push_line("function_call_id += 1");
@@ -1449,10 +1492,6 @@ impl<'src> ClientOutput<'src> {
 		self.push_unreliable();
 
 		self.push_polling();
-
-		if self.config.include_profile_labels {
-			self.push_profiled_callback();
-		}
 
 		self.push_return();
 

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -207,6 +207,10 @@ impl<'src> ClientOutput<'src> {
 	}
 
 	fn push_event_loop_body(&mut self) {
+		if self.config.include_profile_labels {
+			self.push_line("debug.profilebegin(\"Zap Send Events\")");
+		}
+
 		self.push_line("if outgoing_used ~= 0 then");
 		self.indent();
 		self.push_line("local buff = buffer.create(outgoing_used)");
@@ -220,6 +224,11 @@ impl<'src> ClientOutput<'src> {
 		self.push_line("table.clear(outgoing_inst)");
 		self.dedent();
 		self.push_line("end");
+
+		if self.config.include_profile_labels {
+			self.push_line("debug.profileend()");
+		}
+
 		self.dedent();
 	}
 
@@ -241,6 +250,11 @@ impl<'src> ClientOutput<'src> {
 	fn push_reliable_header(&mut self) {
 		self.push_line("reliable.OnClientEvent:Connect(function(buff, inst)");
 		self.indent();
+
+		if self.config.include_profile_labels {
+			self.push_line("debug.profilebegin(\"Zap Reliable OnClientEvent\")");
+		}
+
 		self.push_line("incoming_buff = buff");
 		self.push_line("incoming_inst = inst");
 		self.push_line("incoming_read = 0");
@@ -380,6 +394,10 @@ impl<'src> ClientOutput<'src> {
 
 		self.indent();
 
+		if self.config.include_profile_labels {
+			self.push_line(&format!("debug.profilebegin(\"{} Deserialize\")", ev.name));
+		}
+
 		let values = self.get_values(ev.data.len());
 
 		self.push_line(&format!("local {values}"));
@@ -393,6 +411,10 @@ impl<'src> ClientOutput<'src> {
 				self.config.typescript_enum,
 			);
 			self.push_stmts(statements);
+		}
+
+		if self.config.include_profile_labels {
+			self.push_line("debug.profileend()");
 		}
 
 		match ev.call {
@@ -483,6 +505,10 @@ impl<'src> ClientOutput<'src> {
 
 		self.indent();
 
+		if self.config.include_profile_labels {
+			self.push_line(&format!("debug.profilebegin(\"{} Deserialize\")", fndecl.name));
+		}
+
 		self.push_line("local call_id = buffer.readu8(incoming_buff, read(1))");
 
 		let values = self.get_values(fndecl.rets.as_ref().map_or(0, |x| x.len()));
@@ -498,6 +524,10 @@ impl<'src> ClientOutput<'src> {
 				self.config.typescript_enum,
 			);
 			self.push_stmts(statements);
+		}
+
+		if self.config.include_profile_labels {
+			self.push_line("debug.profileend()");
 		}
 
 		self.push_line(&format!("local thread = reliable_event_queue[{client_id}][call_id]"));
@@ -547,6 +577,11 @@ impl<'src> ClientOutput<'src> {
 		self.push_line("end");
 		self.dedent();
 		self.push_line("end");
+
+		if self.config.include_profile_labels {
+			self.push_line("debug.profileend()");
+		}
+
 		self.dedent();
 		self.push_line("end)");
 	}
@@ -588,6 +623,11 @@ impl<'src> ClientOutput<'src> {
 			id + 1
 		));
 		self.indent();
+
+		if self.config.include_profile_labels {
+			self.push_line(&format!("debug.profilebegin(\"Zap {} OnClientEvent\")", ev.name));
+		}
+
 		self.push_line("incoming_buff = buff");
 		self.push_line("incoming_inst = inst");
 		self.push_line("incoming_read = 0");
@@ -690,6 +730,10 @@ impl<'src> ClientOutput<'src> {
 
 			self.dedent();
 			self.push_line("end");
+		}
+
+		if self.config.include_profile_labels {
+			self.push_line("debug.profileend()");
 		}
 
 		self.dedent();
@@ -815,6 +859,10 @@ impl<'src> ClientOutput<'src> {
 		self.push(")\n");
 		self.indent();
 
+		if self.config.include_profile_labels {
+			self.push_line(&format!("debug.profilebegin(\"{} Fire\")", ev.name));
+		}
+
 		if let EvType::Unreliable(ordered) = ev.evty {
 			let id = ev.id;
 			if ordered {
@@ -854,6 +902,10 @@ impl<'src> ClientOutput<'src> {
 			self.push_line("load(saved)");
 		}
 
+		if self.config.include_profile_labels {
+			self.push_line("debug.profileend()");
+		}
+
 		self.dedent();
 		self.push_line("end,");
 	}
@@ -881,6 +933,13 @@ impl<'src> ClientOutput<'src> {
 
 		self.push(") -> ()): () -> ()\n");
 		self.indent();
+
+		if self.config.include_profile_labels {
+			self.push_line(&format!(
+				"callback = profiledCallback(\"{} Callback\", callback)",
+				ev.name
+			));
+		}
 
 		self.push_line(&format!("{}[{id}] = {callback}", events_table_name(ev)));
 
@@ -949,6 +1008,13 @@ impl<'src> ClientOutput<'src> {
 
 		self.push(") -> ())\n");
 		self.indent();
+
+		if self.config.include_profile_labels {
+			self.push_line(&format!(
+				"callback = profiledCallback(\"{} Callback\", callback)",
+				ev.name
+			));
+		}
 
 		let events_table_name = events_table_name(ev);
 		let event_queue_name = event_queue_table_name(ev);
@@ -1203,6 +1269,10 @@ impl<'src> ClientOutput<'src> {
 						this.push("\n");
 						this.indent();
 
+						if self.config.include_profile_labels {
+							this.push_line(&format!("debug.profilebegin(\"{} Call\")", fndecl.name));
+						}
+
 						this.push_line("function_call_id += 1");
 
 						this.push_line("function_call_id %= 256");
@@ -1239,9 +1309,18 @@ impl<'src> ClientOutput<'src> {
 								this.push_line(&format!(
 									"reliable_event_queue[{client_id}][function_call_id] = coroutine.running()"
 								));
+
+								if self.config.include_profile_labels {
+									this.push_line("debug.profileend()");
+								}
+
 								this.push_line("return coroutine.yield()");
 							}
 							YieldType::Future => {
+								if self.config.include_profile_labels {
+									this.push_line("debug.profileend()");
+								}
+
 								this.push_line("return Future.new(function()");
 								this.indent();
 
@@ -1254,6 +1333,10 @@ impl<'src> ClientOutput<'src> {
 								this.push_line("end)");
 							}
 							YieldType::Promise => {
+								if self.config.include_profile_labels {
+									this.push_line("debug.profileend()");
+								}
+
 								this.push_line("return Promise.new(function(resolve)");
 								this.indent();
 
@@ -1366,6 +1449,10 @@ impl<'src> ClientOutput<'src> {
 		self.push_unreliable();
 
 		self.push_polling();
+
+		if self.config.include_profile_labels {
+			self.push_profiled_callback();
+		}
 
 		self.push_return();
 

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -936,7 +936,7 @@ impl<'src> ClientOutput<'src> {
 
 		if self.config.include_profile_labels {
 			self.push_line(&format!(
-				"callback = profiledCallback(\"{} Callback\", callback)",
+				"{callback} = profiledCallback(\"{} Callback\", {callback})",
 				ev.name
 			));
 		}
@@ -1011,7 +1011,7 @@ impl<'src> ClientOutput<'src> {
 
 		if self.config.include_profile_labels {
 			self.push_line(&format!(
-				"callback = profiledCallback(\"{} Callback\", callback)",
+				"{callback} = profiledCallback(\"{} Callback\", {callback})",
 				ev.name
 			));
 		}

--- a/zap/src/output/luau/mod.rs
+++ b/zap/src/output/luau/mod.rs
@@ -254,6 +254,21 @@ pub trait Output<'src>: ConfigProvider<'src> {
 		));
 		self.push("\n");
 	}
+
+	fn push_profiled_callback(&mut self) {
+		self.push_line("local function profiledCallback(label, callback)");
+		self.indent();
+		self.push_line("return function(...)");
+		self.indent();
+		self.push_line("debug.profilebegin(label)");
+		self.push_line("callback(...)");
+		self.push_line("debug.profileend()");
+		self.dedent();
+		self.push_line("end");
+		self.dedent();
+		self.push_line("end");
+		self.push("\n");
+	}
 }
 
 fn events_table_name<'a>(evdecl: &EvDecl) -> &'a str {

--- a/zap/src/output/luau/mod.rs
+++ b/zap/src/output/luau/mod.rs
@@ -254,21 +254,6 @@ pub trait Output<'src>: ConfigProvider<'src> {
 		));
 		self.push("\n");
 	}
-
-	fn push_profiled_callback(&mut self) {
-		self.push_line("local function profiledCallback(label, callback)");
-		self.indent();
-		self.push_line("return function(...)");
-		self.indent();
-		self.push_line("debug.profilebegin(label)");
-		self.push_line("callback(...)");
-		self.push_line("debug.profileend()");
-		self.dedent();
-		self.push_line("end");
-		self.dedent();
-		self.push_line("end");
-		self.push("\n");
-	}
 }
 
 fn events_table_name<'a>(evdecl: &EvDecl) -> &'a str {

--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -387,7 +387,7 @@ impl<'src> ServerOutput<'src> {
 		self.indent();
 
 		if self.config.include_profile_labels {
-			self.push_line(&format!("debug.profilebegin(\"{} Deserialize\")", ev.name));
+			self.push_line(&format!("debug.profilebegin(\"{} Deserialize\")", ev.display_path()));
 		}
 
 		let values = self.get_values(&ev.data);
@@ -417,12 +417,20 @@ impl<'src> ServerOutput<'src> {
 
 		self.indent();
 
+		if self.config.include_profile_labels && ev.call != EvCall::Polling {
+			self.push_line(&format!("debug.profilebegin(\"{} Callback\")", ev.display_path()));
+		}
+
 		match ev.call {
 			EvCall::SingleSync => self.push_line(&format!("reliable_events[{id}](player, {values})")),
 			EvCall::SingleAsync => self.push_line(&format!("task.spawn(reliable_events[{id}], player, {values})")),
 			EvCall::ManySync => self.push_line(&format!("cb(player, {values})")),
 			EvCall::ManyAsync => self.push_line(&format!("task.spawn(cb, player, {values})")),
 			EvCall::Polling => (),
+		}
+
+		if self.config.include_profile_labels && ev.call != EvCall::Polling {
+			self.push_line("debug.profileend()");
 		}
 
 		self.dedent();
@@ -454,7 +462,10 @@ impl<'src> ServerOutput<'src> {
 		self.indent();
 
 		if self.config.include_profile_labels {
-			self.push_line(&format!("debug.profilebegin(\"{} Deserialize\")", fndecl.name));
+			self.push_line(&format!(
+				"debug.profilebegin(\"{} Deserialize\")",
+				fndecl.display_path()
+			));
 		}
 
 		self.push_line("local call_id = buffer.readu8(buff, read(1))");
@@ -621,7 +632,10 @@ impl<'src> ServerOutput<'src> {
 		self.indent();
 
 		if self.config.include_profile_labels {
-			self.push_line(&format!("debug.profilebegin(\"Zap {} OnServerEvent\")", ev.name));
+			self.push_line(&format!(
+				"debug.profilebegin(\"Zap {} OnServerEvent\")",
+				ev.display_path()
+			));
 		}
 
 		self.push_line("incoming_buff = buff");
@@ -676,6 +690,10 @@ impl<'src> ServerOutput<'src> {
 
 			self.indent();
 
+			if self.config.include_profile_labels {
+				self.push_line(&format!("debug.profilebegin(\"{} Callback\")", ev.display_path()));
+			}
+
 			match ev.call {
 				EvCall::SingleSync => self.push_line(&format!("unreliable_events[{id}](player, {values})")),
 				EvCall::SingleAsync => {
@@ -684,6 +702,10 @@ impl<'src> ServerOutput<'src> {
 				EvCall::ManySync => self.push_line(&format!("cb(player, {values})")),
 				EvCall::ManyAsync => self.push_line(&format!("task.spawn(cb, player, {values})")),
 				EvCall::Polling => (),
+			}
+
+			if self.config.include_profile_labels {
+				self.push_line("debug.profileend()");
 			}
 
 			self.dedent();
@@ -808,7 +830,7 @@ impl<'src> ServerOutput<'src> {
 		self.indent();
 
 		if self.config.include_profile_labels {
-			self.push_line(&format!("debug.profilebegin(\"{} Fire\")", ev.name));
+			self.push_line(&format!("debug.profilebegin(\"{} Fire\")", ev.display_path()));
 		}
 
 		match ev.evty {
@@ -870,7 +892,7 @@ impl<'src> ServerOutput<'src> {
 		self.indent();
 
 		if self.config.include_profile_labels {
-			self.push_line(&format!("debug.profilebegin(\"{} FireAll\")", ev.name));
+			self.push_line(&format!("debug.profilebegin(\"{} FireAll\")", ev.display_path()));
 		}
 
 		self.push_line("load_empty()");
@@ -952,7 +974,7 @@ impl<'src> ServerOutput<'src> {
 		self.indent();
 
 		if self.config.include_profile_labels {
-			self.push_line(&format!("debug.profilebegin(\"{} FireExcept\")", ev.name));
+			self.push_line(&format!("debug.profilebegin(\"{} FireExcept\")", ev.display_path()));
 		}
 
 		self.push_line("load_empty()");
@@ -1039,7 +1061,7 @@ impl<'src> ServerOutput<'src> {
 		self.indent();
 
 		if self.config.include_profile_labels {
-			self.push_line(&format!("debug.profilebegin(\"{} FireList\")", ev.name));
+			self.push_line(&format!("debug.profilebegin(\"{} FireList\")", ev.display_path()));
 		}
 
 		self.push_line("load_empty()");
@@ -1118,7 +1140,7 @@ impl<'src> ServerOutput<'src> {
 		self.indent();
 
 		if self.config.include_profile_labels {
-			self.push_line(&format!("debug.profilebegin(\"{} FireSet\")", ev.name));
+			self.push_line(&format!("debug.profilebegin(\"{} FireSet\")", ev.display_path()));
 		}
 
 		self.push_line("load_empty()");
@@ -1196,13 +1218,6 @@ impl<'src> ServerOutput<'src> {
 		self.push(") -> ()): () -> ()\n");
 		self.indent();
 
-		if self.config.include_profile_labels {
-			self.push_line(&format!(
-				"{callback} = profiledCallback(\"{} Callback\", {callback})",
-				ev.name
-			));
-		}
-
 		self.push_line(&format!("{}[{id}] = {callback}", events_table_name(ev)));
 
 		self.push_line("return function()");
@@ -1234,13 +1249,6 @@ impl<'src> ServerOutput<'src> {
 
 		self.push(") -> ()): () -> ()\n");
 		self.indent();
-
-		if self.config.include_profile_labels {
-			self.push_line(&format!(
-				"{callback} = profiledCallback(\"{} Callback\", {callback})",
-				ev.name
-			));
-		}
 
 		let events_table = events_table_name(ev);
 
@@ -1288,13 +1296,6 @@ impl<'src> ServerOutput<'src> {
 
 		self.push(")): () -> ()\n");
 		self.indent();
-
-		if self.config.include_profile_labels {
-			self.push_line(&format!(
-				"{callback} = profiledCallback(\"{} Callback\", {callback})",
-				fndecl.name
-			));
-		}
 
 		self.push_line(&format!("reliable_events[{server_id}] = {callback}"));
 
@@ -1640,10 +1641,6 @@ impl<'src> ServerOutput<'src> {
 		self.push_unreliable();
 
 		self.push_polling();
-
-		if self.config.include_profile_labels {
-			self.push_profiled_callback();
-		}
 
 		self.push_return();
 

--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -1198,7 +1198,7 @@ impl<'src> ServerOutput<'src> {
 
 		if self.config.include_profile_labels {
 			self.push_line(&format!(
-				"callback = profiledCallback(\"{} Callback\", callback)",
+				"{callback} = profiledCallback(\"{} Callback\", {callback})",
 				ev.name
 			));
 		}
@@ -1237,7 +1237,7 @@ impl<'src> ServerOutput<'src> {
 
 		if self.config.include_profile_labels {
 			self.push_line(&format!(
-				"callback = profiledCallback(\"{} Callback\", callback)",
+				"{callback} = profiledCallback(\"{} Callback\", {callback})",
 				ev.name
 			));
 		}
@@ -1291,7 +1291,7 @@ impl<'src> ServerOutput<'src> {
 
 		if self.config.include_profile_labels {
 			self.push_line(&format!(
-				"callback = profiledCallback(\"{} Callback\", callback)",
+				"{callback} = profiledCallback(\"{} Callback\", {callback})",
 				fndecl.name
 			));
 		}

--- a/zap/src/output/luau/server.rs
+++ b/zap/src/output/luau/server.rs
@@ -199,6 +199,11 @@ impl<'src> ServerOutput<'src> {
 
 		self.push_line(&format!("local function {send_events}()"));
 		self.indent();
+
+		if self.config.include_profile_labels {
+			self.push_line("debug.profilebegin(\"Zap Send Events\")");
+		}
+
 		self.push_line("for player, outgoing in player_map do");
 		self.indent();
 		self.push_line("if outgoing.used > 0 then");
@@ -216,6 +221,11 @@ impl<'src> ServerOutput<'src> {
 		self.push_line("end");
 		self.dedent();
 		self.push_line("end");
+
+		if self.config.include_profile_labels {
+			self.push_line("debug.profileend()");
+		}
+
 		self.dedent();
 		self.push_line("end\n");
 
@@ -227,6 +237,11 @@ impl<'src> ServerOutput<'src> {
 	fn push_reliable_header(&mut self) {
 		self.push_line("reliable.OnServerEvent:Connect(function(player, buff, inst)");
 		self.indent();
+
+		if self.config.include_profile_labels {
+			self.push_line("debug.profilebegin(\"Zap Reliable OnServerEvent\")");
+		}
+
 		self.push_line("incoming_buff = buff");
 		self.push_line("incoming_inst = inst");
 		self.push_line("incoming_read = 0");
@@ -371,6 +386,10 @@ impl<'src> ServerOutput<'src> {
 
 		self.indent();
 
+		if self.config.include_profile_labels {
+			self.push_line(&format!("debug.profilebegin(\"{} Deserialize\")", ev.name));
+		}
+
 		let values = self.get_values(&ev.data);
 
 		self.push_line(&format!("local {values}"));
@@ -384,6 +403,10 @@ impl<'src> ServerOutput<'src> {
 				self.config.typescript_enum,
 			);
 			self.push_stmts(statements);
+		}
+
+		if self.config.include_profile_labels {
+			self.push_line("debug.profileend()");
 		}
 
 		match ev.call {
@@ -430,6 +453,10 @@ impl<'src> ServerOutput<'src> {
 
 		self.indent();
 
+		if self.config.include_profile_labels {
+			self.push_line(&format!("debug.profilebegin(\"{} Deserialize\")", fndecl.name));
+		}
+
 		self.push_line("local call_id = buffer.readu8(buff, read(1))");
 
 		let values = self.get_values(&fndecl.args);
@@ -445,6 +472,10 @@ impl<'src> ServerOutput<'src> {
 				self.config.typescript_enum,
 			);
 			self.push_stmts(statements);
+		}
+
+		if self.config.include_profile_labels {
+			self.push_line("debug.profileend()");
 		}
 
 		self.push_line(&format!("if reliable_events[{server_id}] then"));
@@ -542,6 +573,11 @@ impl<'src> ServerOutput<'src> {
 		self.push_line("end");
 		self.dedent();
 		self.push_line("end");
+
+		if self.config.include_profile_labels {
+			self.push_line("debug.profileend()");
+		}
+
 		self.dedent();
 		self.push_line("end)");
 	}
@@ -583,6 +619,11 @@ impl<'src> ServerOutput<'src> {
 			id + 1
 		));
 		self.indent();
+
+		if self.config.include_profile_labels {
+			self.push_line(&format!("debug.profilebegin(\"Zap {} OnServerEvent\")", ev.name));
+		}
+
 		self.push_line("incoming_buff = buff");
 		self.push_line("incoming_inst = inst");
 		self.push_line("incoming_read = 0");
@@ -647,6 +688,10 @@ impl<'src> ServerOutput<'src> {
 
 			self.dedent();
 			self.push_line("end");
+		}
+
+		if self.config.include_profile_labels {
+			self.push_line("debug.profileend()");
 		}
 
 		self.dedent();
@@ -762,6 +807,10 @@ impl<'src> ServerOutput<'src> {
 		self.push(")\n");
 		self.indent();
 
+		if self.config.include_profile_labels {
+			self.push_line(&format!("debug.profilebegin(\"{} Fire\")", ev.name));
+		}
+
 		match ev.evty {
 			EvType::Reliable => self.push_line(&format!("load_player({player})")),
 			EvType::Unreliable(_) => self.push_line("load_empty()"),
@@ -796,6 +845,10 @@ impl<'src> ServerOutput<'src> {
 			}
 		}
 
+		if self.config.include_profile_labels {
+			self.push_line("debug.profileend()");
+		}
+
 		self.dedent();
 		self.push_line("end,");
 	}
@@ -815,6 +868,10 @@ impl<'src> ServerOutput<'src> {
 
 		self.push(")\n");
 		self.indent();
+
+		if self.config.include_profile_labels {
+			self.push_line(&format!("debug.profilebegin(\"{} FireAll\")", ev.name));
+		}
 
 		self.push_line("load_empty()");
 
@@ -868,6 +925,10 @@ impl<'src> ServerOutput<'src> {
 			}
 		}
 
+		if self.config.include_profile_labels {
+			self.push_line("debug.profileend()");
+		}
+
 		self.dedent();
 		self.push_line("end,");
 	}
@@ -889,6 +950,10 @@ impl<'src> ServerOutput<'src> {
 
 		self.push(")\n");
 		self.indent();
+
+		if self.config.include_profile_labels {
+			self.push_line(&format!("debug.profilebegin(\"{} FireExcept\")", ev.name));
+		}
 
 		self.push_line("load_empty()");
 
@@ -947,6 +1012,10 @@ impl<'src> ServerOutput<'src> {
 			}
 		}
 
+		if self.config.include_profile_labels {
+			self.push_line("debug.profileend()");
+		}
+
 		self.dedent();
 		self.push_line("end,");
 	}
@@ -968,6 +1037,10 @@ impl<'src> ServerOutput<'src> {
 
 		self.push(")\n");
 		self.indent();
+
+		if self.config.include_profile_labels {
+			self.push_line(&format!("debug.profilebegin(\"{} FireList\")", ev.name));
+		}
 
 		self.push_line("load_empty()");
 
@@ -1016,6 +1089,10 @@ impl<'src> ServerOutput<'src> {
 				self.dedent();
 				self.push_line("end");
 			}
+		}
+
+		if self.config.include_profile_labels {
+			self.push_line("debug.profileend()");
 		}
 
 		self.dedent();
@@ -1040,6 +1117,10 @@ impl<'src> ServerOutput<'src> {
 		self.push(")\n");
 		self.indent();
 
+		if self.config.include_profile_labels {
+			self.push_line(&format!("debug.profilebegin(\"{} FireSet\")", ev.name));
+		}
+
 		self.push_line("load_empty()");
 
 		self.push_write_evdecl_event_id(ev);
@@ -1089,6 +1170,10 @@ impl<'src> ServerOutput<'src> {
 			}
 		}
 
+		if self.config.include_profile_labels {
+			self.push_line("debug.profileend()");
+		}
+
 		self.dedent();
 		self.push_line("end,");
 	}
@@ -1110,6 +1195,13 @@ impl<'src> ServerOutput<'src> {
 
 		self.push(") -> ()): () -> ()\n");
 		self.indent();
+
+		if self.config.include_profile_labels {
+			self.push_line(&format!(
+				"callback = profiledCallback(\"{} Callback\", callback)",
+				ev.name
+			));
+		}
 
 		self.push_line(&format!("{}[{id}] = {callback}", events_table_name(ev)));
 
@@ -1142,6 +1234,13 @@ impl<'src> ServerOutput<'src> {
 
 		self.push(") -> ()): () -> ()\n");
 		self.indent();
+
+		if self.config.include_profile_labels {
+			self.push_line(&format!(
+				"callback = profiledCallback(\"{} Callback\", callback)",
+				ev.name
+			));
+		}
 
 		let events_table = events_table_name(ev);
 
@@ -1189,6 +1288,13 @@ impl<'src> ServerOutput<'src> {
 
 		self.push(")): () -> ()\n");
 		self.indent();
+
+		if self.config.include_profile_labels {
+			self.push_line(&format!(
+				"callback = profiledCallback(\"{} Callback\", callback)",
+				fndecl.name
+			));
+		}
 
 		self.push_line(&format!("reliable_events[{server_id}] = {callback}"));
 
@@ -1534,6 +1640,10 @@ impl<'src> ServerOutput<'src> {
 		self.push_unreliable();
 
 		self.push_polling();
+
+		if self.config.include_profile_labels {
+			self.push_profiled_callback();
+		}
 
 		self.push_return();
 

--- a/zap/src/parser/convert.rs
+++ b/zap/src/parser/convert.rs
@@ -210,6 +210,7 @@ impl<'src> Converter<'src> {
 
 		let (write_checks, ..) = self.boolean_opt("write_checks", true, &config.opts);
 		let (manual_event_loop, ..) = self.boolean_opt("manual_event_loop", false, &config.opts);
+		let (include_profile_labels, ..) = self.boolean_opt("include_profile_labels", false, &config.opts);
 
 		let (remote_scope, ..) = self.str_opt("remote_scope", "ZAP", &config.opts);
 		let (remote_folder, ..) = self.str_opt("remote_folder", "ZAP", &config.opts);
@@ -238,6 +239,7 @@ impl<'src> Converter<'src> {
 
 			write_checks,
 			manual_event_loop,
+			include_profile_labels,
 
 			remote_scope,
 			remote_folder,

--- a/zap/tests/files/include_profile_labels.zap
+++ b/zap/tests/files/include_profile_labels.zap
@@ -1,0 +1,36 @@
+opt include_profile_labels = true
+
+event Event1 = {
+    from: Client,
+    type: Reliable,
+    call: SingleSync,
+    data: string.binary
+}
+
+event Event2 = {
+    from: Server,
+    type: Reliable,
+    call: ManySync,
+    data: string.binary
+}
+
+funct Function = {
+    call: Async,
+    rets: string.binary
+}
+
+namespace Namespace = {
+	event Event1 = {
+	    from: Client,
+	    type: Unreliable,
+	    call: SingleAsync,
+	    data: u8
+	}
+
+	event Event2 = {
+	    from: Server,
+	    type: Unreliable,
+	    call: ManyAsync,
+	    data: u8
+	}
+}

--- a/zap/tests/lune/snapshots/run_lune_test@include_profile_labels.snap
+++ b/zap/tests/lune/snapshots/run_lune_test@include_profile_labels.snap
@@ -1,0 +1,8 @@
+---
+source: zap/tests/lune/mod.rs
+expression: result
+input_file: zap/tests/files/include_profile_labels.zap
+---
+Ok(
+    0,
+)

--- a/zap/tests/selene/snapshots/run_selene_test@include_profile_labels@client.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@include_profile_labels@client.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: client_diagnostics
+input_file: zap/tests/files/include_profile_labels.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@include_profile_labels@server.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@include_profile_labels@server.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: server_diagnostics
+input_file: zap/tests/files/include_profile_labels.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@include_profile_labels@tooling.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@include_profile_labels@tooling.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: tooling_diagnostics
+input_file: zap/tests/files/include_profile_labels.zap
+---
+[]

--- a/zap/tests/selene/snapshots/run_selene_test@include_profile_labels@types.snap
+++ b/zap/tests/selene/snapshots/run_selene_test@include_profile_labels@types.snap
@@ -1,0 +1,6 @@
+---
+source: zap/tests/selene/mod.rs
+expression: types_diagnostics
+input_file: zap/tests/files/include_profile_labels.zap
+---
+[]


### PR DESCRIPTION
Feel free to suggest alternative names for the option.

Here are the places labels were added:

- For callbacks:
```lua
local function profiledCallback(label, callback)
	return function(...)
		debug.profilebegin(label)
		callback(...)
		debug.profileend()
	end
end

setCallback = function(callback: (message: (string)) -> ())
    callback = profiledCallback("EventName Callback", callback)
```
- When events/functions are fired/called: `EventName Fire`/`EventName FireAll`/`FunctionName Call`
- In OnClientEvents/OnServerEvents: `Zap Reliable OnClientEvent`/`Zap UnreliableEventName OnClientEvent`
- A label for each event/functions's deserialization: `EventName Deserialize`
- A label for `sendEvents()`: `Zap Send Events`
