### PR TITLE
Feat: Allow requiring zap from edit mode (for Storyboards)

### DIFF
--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -1457,7 +1457,7 @@ impl<'src> ClientOutput<'src> {
 	}
 
 	pub fn push_check_server(&mut self) {
-		self.push_line("if RunService:IsServer() then");
+		self.push_line("if RunService:IsServer() and not RunService:IsEdit() then");
 		self.indent();
 		self.push_line("error(\"Cannot use the client module on the server!\")");
 		self.dedent();

--- a/zap/src/output/luau/client.rs
+++ b/zap/src/output/luau/client.rs
@@ -1457,7 +1457,7 @@ impl<'src> ClientOutput<'src> {
 	}
 
 	pub fn push_check_server(&mut self) {
-		self.push_line("if RunService:IsServer() and not RunService:IsEdit() then");
+		self.push_line("if RunService:IsServer() and RunService:IsRunning() then");
 		self.indent();
 		self.push_line("error(\"Cannot use the client module on the server!\")");
 		self.dedent();


### PR DESCRIPTION
Studio will return true for RunService:IsServer() in edit mode. For testing components using storyboards, any component that requires the client network module will error.

This fix makes it so Zap is allowed to be required while in edit mode even if IsServer returns true